### PR TITLE
Group gomod digest updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Dependencies are selectively grouped and scheduled:
 | Type                              | Grouped | Schedule            |
 | :-------------------------------- | :------ | :------------------ |
 | SEEK                              | No      | Weekday             |
-| Go module                         | No      | Monday, Friday      |
+| Go module digest update           | Yes     | Monthly             |
+| Go module version update          | No      | Monday, Friday      |
 | JavaScript dependency             | No      | Monday, Friday      |
 | JavaScript devDependency          | Yes     | Tuesday             |
 | JavaScript peerDependency         | Yes     | Tuesday             |

--- a/default.json
+++ b/default.json
@@ -18,8 +18,9 @@
     },
     {
       "digest": {
-        "commitMessageExtra": "{{newDigestShort}}",
-        "commitMessageTopic": "{{{depName}}}"
+        "commitMessageExtra": "",
+        "groupName": "gomod digests",
+        "schedule": "before 7am on the first day of the month"
       },
       "managers": ["gomod"],
       "semanticCommitType": "fix"


### PR DESCRIPTION
The golang.org modules (golang.org/x/foo) are essentially always updated. With the current configuration of Mon/Fri updates an no grouping it's like a game of whack-a-mole to get `seek-auth-sidecar`'s PRs merged.

This treats digest updates like `aws-sdk` and only updates digests on the first of the month with grouping.