### PR TITLE
Change default branch prefix to `renovate--`

### DIFF
--- a/default.json
+++ b/default.json
@@ -110,5 +110,6 @@
   "rangeStrategy": "auto",
   "schedule": "before 7am on Monday and Friday",
   "semanticCommitScope": "",
-  "semanticCommitType": "deps"
+  "semanticCommitType": "deps",
+  "branchPrefix": "renovate--"
 }

--- a/default.json
+++ b/default.json
@@ -3,7 +3,6 @@
     ":prHourlyLimit2",
     ":prNotPending",
     ":rebaseStalePrs",
-    ":renovatePrefix",
     ":semanticCommits",
     ":timezone(Australia/Melbourne)",
     ":updateNotScheduled",


### PR DESCRIPTION
Aligning the branch prefix to seek-oss/renovate-config-seek: https://github.com/seek-oss/renovate-config-seek/blob/d090badbc9dbe2f9b9f5c1f5a31dcebe269ba4cc/package.json#L28