### PR TITLE
Match Gantry schedule for non-critical

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ Pull requests are tersely named:
 
 ### `non-critical`
 
-| Type | Grouped | Schedule |
-| :--- | :------ | :------- |
-| \*   | Yes     | Monday   |
+| Type                    | Grouped | Schedule |
+| :---------------------- | :------ | :------- |
+| Gantry Buildkite plugin | No      | Weekday  |
+| \*                      | Yes     | Monday   |
 
-| Type | Example                 |
-| :--- | :---------------------- |
-| \*   | `fix: all dependencies` |
+| Type                    | Example                        |
+| :---------------------- | :----------------------------- |
+| Gantry Buildkite plugin | `fix: seek-jobs/gantry v1.0.0` |
+| \*                      | `fix: all dependencies`        |
 
 ## Usage
 

--- a/non-critical.json
+++ b/non-critical.json
@@ -11,15 +11,17 @@
   ],
   "packageRules": [
     {
-      "groupName": "gantry",
-      "packageNames": ["seek-jobs/gantry"],
-      "prPriority": 99,
-      "schedule": "before 7am on every weekday"
-    },
-    {
+      "excludePackageNames": ["seek-jobs/gantry"],
       "groupName": "all dependencies",
       "packagePatterns": ["*"],
-      "recreateClosed": true
+      "recreateClosed": true,
+      "schedule": "before 7am on Monday"
+    },
+    {
+      "commitMessageAction": "",
+      "commitMessageExtra": "{{newValue}}",
+      "commitMessageTopic": "{{depName}}",
+      "packageNames": ["seek-jobs/gantry"]
     }
   ],
   "buildkite": {
@@ -39,7 +41,7 @@
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 2,
   "prNotPendingHours": 1,
-  "schedule": "before 7am on Monday",
+  "schedule": "before 7am on every weekday",
   "semanticCommitScope": "",
   "semanticCommitType": "fix",
   "separateMajorMinor": false

--- a/non-critical.json
+++ b/non-critical.json
@@ -11,6 +11,12 @@
   ],
   "packageRules": [
     {
+      "groupName": "gantry",
+      "packageNames": ["seek-jobs/gantry"],
+      "prPriority": 99,
+      "schedule": "before 7am on every weekday"
+    },
+    {
       "groupName": "all dependencies",
       "packagePatterns": ["*"],
       "recreateClosed": true


### PR DESCRIPTION
Gantry releases need to be synchronised across a Gantry environment. It's really annoying to have the non-critical packages at a different cadence to the critical ones. Right now I need to manually open PRs for the non-criticals at the same time Renovate opens the critical ones.

I'm not sure how kosher it is to refer to SEEK internal projects from SEEK-OSS. Gantry isn't particularly secret and there's been talk of open sourcing it anyway, however.