### PR TITLE
Automerge pin updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -101,7 +101,7 @@
       "recreateClosed": true
     },
     {
-      "updateTypes": "pin",
+      "updateTypes": ["pin"],
       "automerge": true
     }
   ],

--- a/default.json
+++ b/default.json
@@ -99,6 +99,10 @@
       "packageNames": ["react-relay"],
       "packagePatterns": ["^relay-"],
       "recreateClosed": true
+    },
+    {
+      "updateTypes": "pin",
+      "automerge": true
     }
   ],
   "commitMessageAction": "",


### PR DESCRIPTION
Theoretically these PRs should have no impact on what's installed to `node_modules`. It's easy to forget a pin so it'd be good to clear out these PRs automatically.