### PR TITLE
Automerge @seek/indie-cardib-types

### DIFF
--- a/default.json
+++ b/default.json
@@ -91,6 +91,11 @@
       "schedule": "before 7am on the first day of the month"
     },
     {
+      "automerge": true,
+      "depTypeList": ["devDependencies"],
+      "packageNames": ["@seek/indie-cardib-types"]
+    },
+    {
       "extends": ["group:monorepos"],
       "excludePackageNames": [],
       "recreateClosed": true


### PR DESCRIPTION
This is an internal types package that is equivalent to a DefinitelyTyped package. It's a scoped package so it should be individually PRed and automerged without issue.