### PR TITLE
fix(types/node): Disable major @types/node upgrade

### DIFF
--- a/default.json
+++ b/default.json
@@ -31,6 +31,12 @@
       "managers": ["buildkite", "gomod", "npm", "nvm"]
     },
     {
+      "managers": ["npm"],
+      "packageNames": ["@types/node"],
+      "updateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "automerge": true,
       "commitMessageExtra": "",
       "groupName": "npm definitely typed",


### PR DESCRIPTION
This should match the version of Node the project uses. Right now we're tracking `@types/node@14` which isn't LTS yet.