### PR TITLE
Add candidate data contracts to be auto merged

### DIFF
--- a/default.json
+++ b/default.json
@@ -99,7 +99,7 @@
     {
       "automerge": true,
       "depTypeList": ["devDependencies"],
-      "packageNames": ["@seek/indie-cardib-types", "@seek/ie-shared-types"]
+      "packageNames": ["@seek/indie-cardib-types", "@seek/ie-shared-types", "@seek/candidate-data-contracts"]
     },
     {
       "extends": ["group:monorepos"],


### PR DESCRIPTION
## Purpose 

Candidate Data Contracts defines the types on candidate domain, and it is hard to keep it up to date with all PRs raised by renovate.

Assuming it will be merged only if the buildkite pipeline passes, it would be nice to add it as auto merge same away as the other types library, if possible.