### PR TITLE
Bump hourly PR limit too

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    ":prHourlyLimit2",
+    ":prHourlyLimit4",
     ":rebaseStalePrs",
     ":renovatePrefix",
     ":semanticCommits",


### PR DESCRIPTION
Given we want immediate PRs, this needs to be >= the concurrent limit.