### PR TITLE
Segment scheduled times

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Reference in an [extends] array within [Renovate] config:
 
 ```json5
 {
-  extends: ["github>seek-oss/rynovate"],
+  extends: ['github>seek-oss/rynovate'],
 }
 ```
 
@@ -70,6 +70,6 @@ Choose a named preset with a `:preset` suffix:
 
 ```json5
 {
-  extends: ["github>seek-oss/rynovate:non-critical"],
+  extends: ['github>seek-oss/rynovate:non-critical'],
 }
 ```

--- a/default.json
+++ b/default.json
@@ -19,7 +19,7 @@
       "digest": {
         "commitMessageExtra": "",
         "groupName": "gomod digests",
-        "schedule": "before 7am on the first day of the month"
+        "schedule": "after 3am and before 6am on the first day of the month"
       },
       "managers": ["gomod"],
       "semanticCommitType": "fix"
@@ -43,7 +43,7 @@
       "packagePatterns": ["^@types/"],
       "prPriority": 99,
       "recreateClosed": true,
-      "schedule": "before 7am on Tuesday"
+      "schedule": "before 3am on Tuesday"
     },
     {
       "commitMessageExtra": "",
@@ -53,7 +53,7 @@
       "groupName": "npm dev dependencies",
       "managers": ["npm"],
       "recreateClosed": true,
-      "schedule": "before 7am on Tuesday"
+      "schedule": "after 3am and before 6am on Tuesday"
     },
     {
       "commitMessageExtra": "",
@@ -63,7 +63,7 @@
       "groupName": "npm peer dependencies",
       "managers": ["npm"],
       "recreateClosed": true,
-      "schedule": "before 7am on Tuesday"
+      "schedule": "after 3am and before 6am on Tuesday"
     },
     {
       "commitMessageExtra": "",
@@ -72,7 +72,7 @@
       "managerBranchPrefix": "",
       "managers": ["buildkite"],
       "recreateClosed": true,
-      "schedule": "before 7am on Wednesday"
+      "schedule": "after 3am and before 6am on Wednesday"
     },
     {
       "commitMessageExtra": "",
@@ -82,18 +82,18 @@
       "groupName": "docker images",
       "managers": ["docker-compose", "dockerfile"],
       "recreateClosed": true,
-      "schedule": "before 7am on Wednesday"
+      "schedule": "after 3am and before 6am on Wednesday"
     },
     {
       "packageNames": ["braid-design-system", "sku", "skuba"],
       "packagePatterns": ["^@?seek", "seek$"],
       "prPriority": 98,
-      "schedule": "before 7am on every weekday"
+      "schedule": "after 3am and before 6am on every weekday"
     },
     {
       "depTypeList": ["dependencies"],
       "packageNames": ["aws-sdk"],
-      "schedule": "before 7am on the first day of the month"
+      "schedule": "after 3am and before 6am on the first day of the month"
     },
     {
       "automerge": true,
@@ -102,7 +102,8 @@
         "@seek/candidate-data-contracts",
         "@seek/ie-shared-types",
         "@seek/indie-cardib-types"
-      ]
+      ],
+      "schedule": "before 3am on every weekday"
     },
     {
       "automerge": true,
@@ -124,7 +125,7 @@
     {
       "automerge": true,
       "prPriority": 99,
-      "schedule": "before 7am on every weekday",
+      "schedule": "before 3am on every weekday",
       "updateTypes": ["pin"]
     }
   ],
@@ -135,7 +136,7 @@
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,
   "rangeStrategy": "auto",
-  "schedule": "before 7am on Monday and Friday",
+  "schedule": "after 3am and before 6am on Monday and Friday",
   "semanticCommitScope": "",
   "semanticCommitType": "deps"
 }


### PR DESCRIPTION
This breaks up our renovation across two broad timeslots:

- 12am to 3am for automergable dependencies
- 3am to 6am for manually triaged dependencies

The idea is to reduce build agent contention, particularly in the case of automergable dependencies. If these are automatically merged before other PRs are raised, we can eliminate concurrent builds that are made redundant once Renovate rebases on top of the automerged PR.

We can go further in spacing out our schedules; this is just a start that still sticks the high-level schedule documented in the README.