### PR TITLE
Schedule AWS SDK v3 packages monthly

### DIFF
--- a/default.json
+++ b/default.json
@@ -93,6 +93,7 @@
     {
       "depTypeList": ["dependencies"],
       "packageNames": ["aws-sdk"],
+      "packagePatterns": ["^@aws-sdk/"],
       "schedule": "after 3am and before 6am on the first day of the month"
     },
     {

--- a/default.json
+++ b/default.json
@@ -91,9 +91,13 @@
       "schedule": "after 3am and before 6am on every weekday"
     },
     {
+      "commitMessageExtra": "",
       "depTypeList": ["dependencies"],
+      "groupName": "aws-sdk",
+      "managers": ["npm"],
       "packageNames": ["aws-sdk"],
       "packagePatterns": ["^@aws-sdk/"],
+      "recreateClosed": true,
       "schedule": "after 3am and before 6am on the first day of the month"
     },
     {


### PR DESCRIPTION
These are released in lockstep so are arguably more noisy than v2.