### PR TITLE
Enable lock file maintenance for prod presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,20 @@ See [renovate-config-seek] for a baseline preset that only maintains SEEK npm pa
 
 Dependencies are selectively grouped and scheduled:
 
-| Type                              | Grouped | Schedule            |
-| :-------------------------------- | :------ | :------------------ |
-| SEEK                              | No      | Weekday             |
-| Pin dependency                    | Yes     | Weekday, automerged |
-| Go module digest update           | Yes     | Monthly             |
-| Go module version update          | No      | Monday, Friday      |
-| JavaScript dependency             | No      | Monday, Friday      |
-| JavaScript devDependency          | Yes     | Tuesday             |
-| JavaScript peerDependency         | Yes     | Tuesday             |
-| TypeScript definition             | Yes     | Tuesday, automerged |
-| Buildkite plugin                  | Yes     | Wednesday           |
-| Docker image                      | Yes     | Wednesday           |
-| Noisy dependency (e.g. `aws-sdk`) | No      | Monthly             |
+| Type                              | Grouped | Schedule              |
+| :-------------------------------- | :------ | :-------------------- |
+| SEEK                              | No      | Weekday               |
+| Pin dependency                    | Yes     | Weekday, automerged   |
+| Go module digest update           | Yes     | Monthly               |
+| Go module version update          | No      | Monday, Friday        |
+| JavaScript dependency             | No      | Monday, Friday        |
+| JavaScript devDependency          | Yes     | Tuesday               |
+| JavaScript peerDependency         | Yes     | Tuesday               |
+| TypeScript definition             | Yes     | Tuesday, automerged   |
+| Buildkite plugin                  | Yes     | Wednesday             |
+| Docker image                      | Yes     | Wednesday             |
+| Lockfile maintenance              | Yes     | Wednesday, automerged |
+| Noisy dependency (e.g. `aws-sdk`) | No      | Monthly               |
 
 Pull requests are tersely named:
 
@@ -56,7 +57,7 @@ Pull requests are tersely named:
 
 ### `third-party-major`
 
-Same as the `default` preset, but less noisy as only monitors major updates for non-SEEK deps.
+Like the `default` preset, but less noisy as it only monitors major updates for non-SEEK deps.
 Non-major Buildkite plugin and Docker image versions are still renovated.
 
 ## Usage

--- a/default.json
+++ b/default.json
@@ -10,6 +10,9 @@
     "preview:dockerCompose",
     "docker:disableMajor"
   ],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "depTypeList": ["dependencies"],
@@ -43,7 +46,8 @@
       "packagePatterns": ["^@types/"],
       "prPriority": 99,
       "recreateClosed": true,
-      "schedule": "before 3am on Tuesday"
+      "schedule": "before 3am on Tuesday",
+      "updateTypes": ["major", "minor", "patch"]
     },
     {
       "commitMessageExtra": "",
@@ -53,7 +57,8 @@
       "groupName": "npm dev dependencies",
       "managers": ["npm"],
       "recreateClosed": true,
-      "schedule": "after 3am and before 6am on Tuesday"
+      "schedule": "after 3am and before 6am on Tuesday",
+      "updateTypes": ["major", "minor", "patch"]
     },
     {
       "commitMessageExtra": "",
@@ -63,7 +68,8 @@
       "groupName": "npm peer dependencies",
       "managers": ["npm"],
       "recreateClosed": true,
-      "schedule": "after 3am and before 6am on Tuesday"
+      "schedule": "after 3am and before 6am on Tuesday",
+      "updateTypes": ["major", "minor", "patch"]
     },
     {
       "commitMessageExtra": "",
@@ -126,6 +132,12 @@
       "packageNames": ["react-relay"],
       "packagePatterns": ["^relay-"],
       "recreateClosed": true
+    },
+    {
+      "automerge": true,
+      "prPriority": 99,
+      "schedule": "before 3:00 am every 2 weeks on Wednesday",
+      "updateTypes": ["lockFileMaintenance"]
     },
     {
       "automerge": true,

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -10,6 +10,9 @@
     "preview:dockerCompose",
     "docker:disableMajor"
   ],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "depTypeList": ["dependencies"],
@@ -71,8 +74,15 @@
     {
       "automerge": true,
       "prPriority": 99,
-      "schedule": "before 3am on every weekday",
-      "matchUpdateTypes": ["pin"]
+      "schedule": "before 3:00 am every 2 weeks on Wednesday",
+      "updateTypes": ["lockFileMaintenance"]
+    },
+    {
+      "automerge": true,
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["pin"],
+      "prPriority": 99,
+      "schedule": "before 3am on every weekday"
     }
   ],
   "commitMessageAction": "",


### PR DESCRIPTION
As discussed on Slack, this alleviates busywork in tracking down vulnerabilities in transitive dependencies.