### PR TITLE
Spell out `h:mm` in schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ See [renovate-config-seek] for a baseline preset that only maintains SEEK npm pa
 
 Dependencies are selectively grouped and scheduled:
 
-| Type                              | Grouped | Schedule              |
-| :-------------------------------- | :------ | :-------------------- |
-| SEEK                              | No      | Weekday               |
-| Pin dependency                    | Yes     | Weekday, automerged   |
-| Go module digest update           | Yes     | Monthly               |
-| Go module version update          | No      | Monday, Friday        |
-| JavaScript dependency             | No      | Monday, Friday        |
-| JavaScript devDependency          | Yes     | Tuesday               |
-| JavaScript peerDependency         | Yes     | Tuesday               |
-| TypeScript definition             | Yes     | Tuesday, automerged   |
-| Buildkite plugin                  | Yes     | Wednesday             |
-| Docker image                      | Yes     | Wednesday             |
-| Lockfile maintenance              | Yes     | Wednesday, automerged |
-| Noisy dependency (e.g. `aws-sdk`) | No      | Monthly               |
+| Type                              | Grouped | Schedule                             |
+| :-------------------------------- | :------ | :----------------------------------- |
+| SEEK                              | No      | Weekday                              |
+| Pin dependency                    | Yes     | Weekday, automerged                  |
+| Go module digest update           | Yes     | Monthly                              |
+| Go module version update          | No      | Monday, Friday                       |
+| JavaScript dependency             | No      | Monday, Friday                       |
+| JavaScript devDependency          | Yes     | Tuesday                              |
+| JavaScript peerDependency         | Yes     | Tuesday                              |
+| TypeScript definition             | Yes     | Tuesday, automerged                  |
+| Buildkite plugin                  | Yes     | Wednesday                            |
+| Docker image                      | Yes     | Wednesday                            |
+| Lock file maintenance             | Yes     | Fortnightly on Wednesday, automerged |
+| Noisy dependency (e.g. `aws-sdk`) | No      | Monthly                              |
 
 Pull requests are tersely named:
 

--- a/default.json
+++ b/default.json
@@ -22,7 +22,7 @@
       "digest": {
         "commitMessageExtra": "",
         "groupName": "gomod digests",
-        "schedule": "after 3am and before 6am on the first day of the month"
+        "schedule": "after 3:00 am and before 6:00 am on the first day of the month"
       },
       "managers": ["gomod"],
       "semanticCommitType": "fix"
@@ -46,7 +46,7 @@
       "packagePatterns": ["^@types/"],
       "prPriority": 99,
       "recreateClosed": true,
-      "schedule": "before 3am on Tuesday",
+      "schedule": "before 3:00 am on Tuesday",
       "updateTypes": ["major", "minor", "patch"]
     },
     {
@@ -57,7 +57,7 @@
       "groupName": "npm dev dependencies",
       "managers": ["npm"],
       "recreateClosed": true,
-      "schedule": "after 3am and before 6am on Tuesday",
+      "schedule": "after 3:00 am and before 6:00 am on Tuesday",
       "updateTypes": ["major", "minor", "patch"]
     },
     {
@@ -68,7 +68,7 @@
       "groupName": "npm peer dependencies",
       "managers": ["npm"],
       "recreateClosed": true,
-      "schedule": "after 3am and before 6am on Tuesday",
+      "schedule": "after 3:00 am and before 6:00 am on Tuesday",
       "updateTypes": ["major", "minor", "patch"]
     },
     {
@@ -78,7 +78,7 @@
       "managerBranchPrefix": "",
       "managers": ["buildkite"],
       "recreateClosed": true,
-      "schedule": "after 3am and before 6am on Wednesday"
+      "schedule": "after 3:00 am and before 6:00 am on Wednesday"
     },
     {
       "commitMessageExtra": "",
@@ -88,13 +88,13 @@
       "groupName": "docker images",
       "managers": ["docker-compose", "dockerfile"],
       "recreateClosed": true,
-      "schedule": "after 3am and before 6am on Wednesday"
+      "schedule": "after 3:00 am and before 6:00 am on Wednesday"
     },
     {
       "packageNames": ["braid-design-system", "sku", "skuba"],
       "packagePatterns": ["^@?seek", "seek$"],
       "prPriority": 98,
-      "schedule": "after 3am and before 6am on every weekday"
+      "schedule": "after 3:00 am and before 6:00 am on every weekday"
     },
     {
       "commitMessageExtra": "",
@@ -104,7 +104,7 @@
       "packageNames": ["aws-sdk"],
       "packagePatterns": ["^@aws-sdk/"],
       "recreateClosed": true,
-      "schedule": "after 3am and before 6am on the first day of the month"
+      "schedule": "after 3:00 am and before 6:00 am on the first day of the month"
     },
     {
       "automerge": true,
@@ -114,7 +114,7 @@
         "@seek/ie-shared-types",
         "@seek/indie-cardib-types"
       ],
-      "schedule": "before 3am on every weekday"
+      "schedule": "before 3:00 am on every weekday"
     },
     {
       "automerge": true,
@@ -142,7 +142,7 @@
     {
       "automerge": true,
       "prPriority": 99,
-      "schedule": "before 3am on every weekday",
+      "schedule": "before 3:00 am on every weekday",
       "updateTypes": ["pin"]
     }
   ],
@@ -153,7 +153,7 @@
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,
   "rangeStrategy": "auto",
-  "schedule": "after 3am and before 6am on Monday and Friday",
+  "schedule": "after 3:00 am and before 6:00 am on Monday and Friday",
   "semanticCommitScope": "",
   "semanticCommitType": "deps"
 }

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -36,7 +36,7 @@
       "excludePackagePatterns": ["^@?seek", "seek$", "^@types/"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"],
-      "schedule": "after 3am and before 6am on Tuesday"
+      "schedule": "after 3:00 am and before 6:00 am on Tuesday"
     },
     {
       "depTypeList": ["peerDependencies"],
@@ -44,7 +44,7 @@
       "excludePackagePatterns": ["^@?seek", "seek$", "^@types/"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"],
-      "schedule": "after 3am and before 6am on Tuesday"
+      "schedule": "after 3:00 am and before 6:00 am on Tuesday"
     },
     {
       "commitMessageExtra": "",
@@ -53,7 +53,7 @@
       "managerBranchPrefix": "",
       "matchManagers": ["buildkite"],
       "recreateClosed": true,
-      "schedule": "after 3am and before 6am on Wednesday"
+      "schedule": "after 3:00 am and before 6:00 am on Wednesday"
     },
     {
       "commitMessageExtra": "",
@@ -63,13 +63,13 @@
       "groupName": "docker images",
       "matchManagers": ["docker-compose", "dockerfile"],
       "recreateClosed": true,
-      "schedule": "after 3am and before 6am on Wednesday"
+      "schedule": "after 3:00 am and before 6:00 am on Wednesday"
     },
     {
       "matchPackageNames": ["braid-design-system", "sku", "skuba"],
       "matchPackagePatterns": ["^@?seek", "seek$"],
       "prPriority": 98,
-      "schedule": "after 3am and before 6am on every weekday"
+      "schedule": "after 3:00 am and before 6:00 am on every weekday"
     },
     {
       "automerge": true,
@@ -82,7 +82,7 @@
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["pin"],
       "prPriority": 99,
-      "schedule": "before 3am on every weekday"
+      "schedule": "before 3:00 am on every weekday"
     }
   ],
   "commitMessageAction": "",
@@ -92,7 +92,7 @@
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,
   "rangeStrategy": "auto",
-  "schedule": "after 3am and before 6am on Monday and Friday",
+  "schedule": "after 3:00 am and before 6:00 am on Monday and Friday",
   "semanticCommitScope": "",
   "semanticCommitType": "deps"
 }


### PR DESCRIPTION
Landing #25 required a small battle with `@breejs/later` to get it to recognise a fortnightly schedule. It seems the minutes are the key to getting the text parser to work here.

This opens up the door for us to bump a few other things to a fortnightly schedule, but I'll leave that to another PR.