### PR TITLE
Migrate package rules to matcher style

### DIFF
--- a/default.json
+++ b/default.json
@@ -83,9 +83,9 @@
       "excludePackagePatterns": ["^seek-jobs/", "^seek-oss/"],
       "matchManagers": ["buildkite"],
 
+      "additionalBranchPrefix": "",
       "commitMessageExtra": "",
       "groupName": "buildkite plugins",
-      "managerBranchPrefix": "",
       "recreateClosed": true,
       "schedule": "after 3:00 am and before 6:00 am on Wednesday"
     },
@@ -105,7 +105,7 @@
       "matchPackagePatterns": ["^@?seek", "seek$"],
 
       "prPriority": 98,
-      "schedule": "after 3:00 am and before 6:00 am on every weekday"
+      "schedule": "after 3:00 am and before 6:00 am every weekday"
     },
     {
       "matchDepTypes": ["dependencies"],
@@ -128,7 +128,7 @@
       ],
 
       "automerge": true,
-      "schedule": "before 3:00 am on every weekday"
+      "schedule": "before 3:00 am every weekday"
     },
     {
       "matchDepTypes": ["devDependencies"],
@@ -162,12 +162,10 @@
 
       "automerge": true,
       "prPriority": 99,
-      "schedule": "before 3:00 am on every weekday"
+      "schedule": "before 3:00 am every weekday"
     }
   ],
   "commitMessageAction": "",
-  "ignoreNpmrcFile": true,
-  "lazyGrouping": false,
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,

--- a/default.json
+++ b/default.json
@@ -15,135 +15,154 @@
   },
   "packageRules": [
     {
-      "depTypeList": ["dependencies"],
+      "matchDepTypes": ["dependencies"],
+      "matchManagers": ["npm"],
+
       "semanticCommitType": "fix"
     },
     {
+      "matchManagers": ["gomod"],
+
       "digest": {
         "commitMessageExtra": "",
         "groupName": "gomod digests",
         "schedule": "after 3:00 am and before 6:00 am on the first day of the month"
       },
-      "managers": ["gomod"],
       "semanticCommitType": "fix"
     },
     {
+      "matchManagers": ["buildkite", "gomod", "npm", "nvm"],
+
       "commitMessageExtra": "{{newValue}}",
-      "commitMessageTopic": "{{depName}}",
-      "managers": ["buildkite", "gomod", "npm", "nvm"]
+      "commitMessageTopic": "{{depName}}"
     },
     {
-      "managers": ["npm"],
-      "packageNames": ["@types/node"],
-      "updateTypes": ["major"],
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@types/node"],
+      "matchUpdateTypes": ["major"],
+
       "enabled": false
     },
     {
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@types/"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+
       "automerge": true,
       "commitMessageExtra": "",
       "groupName": "npm definitely typed",
-      "managers": ["npm"],
-      "packagePatterns": ["^@types/"],
       "prPriority": 99,
       "recreateClosed": true,
-      "schedule": "before 3:00 am on Tuesday",
-      "updateTypes": ["major", "minor", "patch"]
+      "schedule": "before 3:00 am on Tuesday"
     },
     {
-      "commitMessageExtra": "",
-      "depTypeList": ["devDependencies"],
       "excludePackageNames": ["braid-design-system", "sku", "skuba"],
       "excludePackagePatterns": ["^@?seek", "seek$", "^@types/"],
+      "matchDepTypes": ["devDependencies"],
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+
+      "commitMessageExtra": "",
       "groupName": "npm dev dependencies",
-      "managers": ["npm"],
       "recreateClosed": true,
-      "schedule": "after 3:00 am and before 6:00 am on Tuesday",
-      "updateTypes": ["major", "minor", "patch"]
+      "schedule": "after 3:00 am and before 6:00 am on Tuesday"
     },
     {
-      "commitMessageExtra": "",
-      "depTypeList": ["peerDependencies"],
       "excludePackageNames": ["braid-design-system", "sku", "skuba"],
       "excludePackagePatterns": ["^@?seek", "seek$", "^@types/"],
+      "matchDepTypes": ["peerDependencies"],
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+
+      "commitMessageExtra": "",
       "groupName": "npm peer dependencies",
-      "managers": ["npm"],
       "recreateClosed": true,
-      "schedule": "after 3:00 am and before 6:00 am on Tuesday",
-      "updateTypes": ["major", "minor", "patch"]
+      "schedule": "after 3:00 am and before 6:00 am on Tuesday"
     },
     {
-      "commitMessageExtra": "",
       "excludePackagePatterns": ["^seek-jobs/", "^seek-oss/"],
+      "matchManagers": ["buildkite"],
+
+      "commitMessageExtra": "",
       "groupName": "buildkite plugins",
       "managerBranchPrefix": "",
-      "managers": ["buildkite"],
       "recreateClosed": true,
       "schedule": "after 3:00 am and before 6:00 am on Wednesday"
     },
     {
+      "matchManagers": ["docker-compose", "dockerfile"],
+
       "commitMessageExtra": "",
       "group": {
         "commitMessageTopic": "{{groupName}}"
       },
       "groupName": "docker images",
-      "managers": ["docker-compose", "dockerfile"],
       "recreateClosed": true,
       "schedule": "after 3:00 am and before 6:00 am on Wednesday"
     },
     {
-      "packageNames": ["braid-design-system", "sku", "skuba"],
-      "packagePatterns": ["^@?seek", "seek$"],
+      "matchPackageNames": ["braid-design-system", "sku", "skuba"],
+      "matchPackagePatterns": ["^@?seek", "seek$"],
+
       "prPriority": 98,
       "schedule": "after 3:00 am and before 6:00 am on every weekday"
     },
     {
+      "matchDepTypes": ["dependencies"],
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["aws-sdk"],
+      "matchPackagePatterns": ["^@aws-sdk/"],
+
       "commitMessageExtra": "",
-      "depTypeList": ["dependencies"],
       "groupName": "aws-sdk",
-      "managers": ["npm"],
-      "packageNames": ["aws-sdk"],
-      "packagePatterns": ["^@aws-sdk/"],
       "recreateClosed": true,
       "schedule": "after 3:00 am and before 6:00 am on the first day of the month"
     },
     {
-      "automerge": true,
-      "depTypeList": ["devDependencies"],
-      "packageNames": [
+      "matchDepTypes": ["devDependencies"],
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
         "@seek/candidate-data-contracts",
         "@seek/ie-shared-types",
         "@seek/indie-cardib-types"
       ],
+
+      "automerge": true,
       "schedule": "before 3:00 am on every weekday"
     },
     {
-      "automerge": true,
-      "depTypeList": ["devDependencies"],
-      "packageNames": ["sku", "skuba"],
-      "updateTypes": ["patch"]
+      "matchDepTypes": ["devDependencies"],
+      "matchPackageNames": ["sku", "skuba"],
+      "matchUpdateTypes": ["patch"],
+
+      "automerge": true
     },
     {
-      "extends": ["group:monorepos"],
       "excludePackageNames": [],
+
+      "extends": ["group:monorepos"],
       "recreateClosed": true
     },
     {
+      "matchPackageNames": ["react-relay"],
+      "matchPackagePatterns": ["^relay-"],
+
       "groupName": "relay",
-      "packageNames": ["react-relay"],
-      "packagePatterns": ["^relay-"],
       "recreateClosed": true
     },
     {
+      "matchUpdateTypes": ["lockFileMaintenance"],
+
       "automerge": true,
       "prPriority": 99,
-      "schedule": "before 3:00 am every 2 weeks on Wednesday",
-      "updateTypes": ["lockFileMaintenance"]
+      "schedule": "before 3:00 am every 2 weeks on Wednesday"
     },
     {
+      "matchUpdateTypes": ["pin"],
+
       "automerge": true,
       "prPriority": 99,
-      "schedule": "before 3:00 am on every weekday",
-      "updateTypes": ["pin"]
+      "schedule": "before 3:00 am on every weekday"
     }
   ],
   "commitMessageAction": "",

--- a/non-critical.json
+++ b/non-critical.json
@@ -33,12 +33,12 @@
       "commitMessageAction": "",
       "commitMessageExtra": "{{newValue}}",
       "commitMessageTopic": "{{depName}}",
-      "schedule": "before 6:00 am on every weekday"
+      "schedule": "before 6:00 am every weekday"
     }
   ],
   "buildkite": {
-    "commitMessageExtra": "",
-    "managerBranchPrefix": ""
+    "additionalBranchPrefix": "",
+    "commitMessageExtra": ""
   },
   "docker": {
     "commitMessageExtra": "",
@@ -48,8 +48,6 @@
   },
   "commitMessageAction": "",
   "commitMessageExtra": "",
-  "ignoreNpmrcFile": true,
-  "lazyGrouping": false,
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 2,
   "prNotPendingHours": 1,

--- a/non-critical.json
+++ b/non-critical.json
@@ -12,10 +12,7 @@
   "packageRules": [
     {
       "excludePackageNames": ["seek-jobs/gantry"],
-      "groupName": "all dependencies",
-      "recreateClosed": true,
-      "semanticCommitType": "fix",
-      "updateTypes": [
+      "matchUpdateTypes": [
         "bump",
         "digest",
         "major",
@@ -23,13 +20,19 @@
         "patch",
         "pin",
         "rollback"
-      ]
+      ],
+
+      "groupName": "all dependencies",
+      "recreateClosed": true,
+      "semanticCommitType": "fix"
     },
     {
+      "matchManagers": ["buildkite"],
+      "matchPackageNames": ["seek-jobs/gantry"],
+
       "commitMessageAction": "",
       "commitMessageExtra": "{{newValue}}",
       "commitMessageTopic": "{{depName}}",
-      "packageNames": ["seek-jobs/gantry"],
       "schedule": "before 6:00 am on every weekday"
     }
   ],

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -56,9 +56,9 @@
       "excludePackagePatterns": ["^seek-jobs/", "^seek-oss/"],
       "matchManagers": ["buildkite"],
 
+      "additionalBranchPrefix": "",
       "commitMessageExtra": "",
       "groupName": "buildkite plugins",
-      "managerBranchPrefix": "",
       "recreateClosed": true,
       "schedule": "after 3:00 am and before 6:00 am on Wednesday"
     },
@@ -78,7 +78,7 @@
       "matchPackagePatterns": ["^@?seek", "seek$"],
 
       "prPriority": 98,
-      "schedule": "after 3:00 am and before 6:00 am on every weekday"
+      "schedule": "after 3:00 am and before 6:00 am every weekday"
     },
     {
       "matchUpdateTypes": ["lockFileMaintenance"],
@@ -92,12 +92,10 @@
 
       "automerge": true,
       "prPriority": 99,
-      "schedule": "before 3:00 am on every weekday"
+      "schedule": "before 3:00 am every weekday"
     }
   ],
   "commitMessageAction": "",
-  "ignoreNpmrcFile": true,
-  "lazyGrouping": false,
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -15,7 +15,7 @@
   },
   "packageRules": [
     {
-      "matchDevTypes": ["dependencies"],
+      "matchDepTypes": ["dependencies"],
       "matchManagers": ["npm"],
 
       "semanticCommitType": "fix"

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -15,72 +15,82 @@
   },
   "packageRules": [
     {
-      "depTypeList": ["dependencies"],
+      "matchDevTypes": ["dependencies"],
+      "matchManagers": ["npm"],
+
       "semanticCommitType": "fix"
     },
     {
+      "matchManagers": ["buildkite", "npm", "nvm"],
+
       "commitMessageExtra": "{{newValue}}",
-      "commitMessageTopic": "{{depName}}",
-      "matchManagers": ["buildkite", "npm", "nvm"]
+      "commitMessageTopic": "{{depName}}"
     },
     {
       "excludePackageNames": ["braid-design-system", "sku", "skuba"],
       "excludePackagePatterns": ["^@?seek", "seek$"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["patch", "minor"],
+
       "enabled": false
     },
     {
-      "depTypeList": ["devDependencies"],
       "excludePackageNames": ["braid-design-system", "sku", "skuba"],
       "excludePackagePatterns": ["^@?seek", "seek$", "^@types/"],
+      "matchDepTypes": ["devDependencies"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"],
+
       "schedule": "after 3:00 am and before 6:00 am on Tuesday"
     },
     {
-      "depTypeList": ["peerDependencies"],
       "excludePackageNames": ["braid-design-system", "sku", "skuba"],
       "excludePackagePatterns": ["^@?seek", "seek$", "^@types/"],
+      "matchDepTypes": ["peerDependencies"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major"],
+
       "schedule": "after 3:00 am and before 6:00 am on Tuesday"
     },
     {
-      "commitMessageExtra": "",
       "excludePackagePatterns": ["^seek-jobs/", "^seek-oss/"],
+      "matchManagers": ["buildkite"],
+
+      "commitMessageExtra": "",
       "groupName": "buildkite plugins",
       "managerBranchPrefix": "",
-      "matchManagers": ["buildkite"],
       "recreateClosed": true,
       "schedule": "after 3:00 am and before 6:00 am on Wednesday"
     },
     {
+      "matchManagers": ["docker-compose", "dockerfile"],
+
       "commitMessageExtra": "",
       "group": {
         "commitMessageTopic": "{{groupName}}"
       },
       "groupName": "docker images",
-      "matchManagers": ["docker-compose", "dockerfile"],
       "recreateClosed": true,
       "schedule": "after 3:00 am and before 6:00 am on Wednesday"
     },
     {
       "matchPackageNames": ["braid-design-system", "sku", "skuba"],
       "matchPackagePatterns": ["^@?seek", "seek$"],
+
       "prPriority": 98,
       "schedule": "after 3:00 am and before 6:00 am on every weekday"
     },
     {
+      "matchUpdateTypes": ["lockFileMaintenance"],
+
       "automerge": true,
       "prPriority": 99,
-      "schedule": "before 3:00 am every 2 weeks on Wednesday",
-      "updateTypes": ["lockFileMaintenance"]
+      "schedule": "before 3:00 am every 2 weeks on Wednesday"
     },
     {
-      "automerge": true,
-      "matchManagers": ["npm"],
       "matchUpdateTypes": ["pin"],
+
+      "automerge": true,
       "prPriority": 99,
       "schedule": "before 3:00 am on every weekday"
     }


### PR DESCRIPTION
Renovate has revised the names of "matcher" properties in package rules to delineate what is rule scope and what is rule configuration.

https://docs.renovatebot.com/configuration-options/#packagerules