### PR TITLE
Move `group:monorepos` to root

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,8 @@
     ":updateNotScheduled",
     "preview:buildkite",
     "preview:dockerCompose",
-    "docker:disableMajor"
+    "docker:disableMajor",
+    "group:monorepos"
   ],
   "lockFileMaintenance": {
     "enabled": true
@@ -136,12 +137,6 @@
       "matchUpdateTypes": ["patch"],
 
       "automerge": true
-    },
-    {
-      "excludePackageNames": [],
-
-      "extends": ["group:monorepos"],
-      "recreateClosed": true
     },
     {
       "matchPackageNames": ["react-relay"],


### PR DESCRIPTION
My manual testing over at https://github.com/72636c/the-block/pull/1 hasn't uncovered any regressions. The previous nesting in `packageRules` is frowned upon by Renovate.