### PR TITLE
Move catch-all rules to the start

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,10 +16,10 @@
   },
   "packageRules": [
     {
-      "matchDepTypes": ["dependencies"],
-      "matchManagers": ["npm"],
+      "matchManagers": ["buildkite", "gomod", "npm", "nvm"],
 
-      "semanticCommitType": "fix"
+      "commitMessageExtra": "{{newValue}}",
+      "commitMessageTopic": "{{depName}}"
     },
     {
       "matchManagers": ["gomod"],
@@ -32,10 +32,10 @@
       "semanticCommitType": "fix"
     },
     {
-      "matchManagers": ["buildkite", "gomod", "npm", "nvm"],
+      "matchDepTypes": ["dependencies"],
+      "matchManagers": ["npm"],
 
-      "commitMessageExtra": "{{newValue}}",
-      "commitMessageTopic": "{{depName}}"
+      "semanticCommitType": "fix"
     },
     {
       "matchManagers": ["npm"],

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -15,16 +15,16 @@
   },
   "packageRules": [
     {
-      "matchDepTypes": ["dependencies"],
-      "matchManagers": ["npm"],
-
-      "semanticCommitType": "fix"
-    },
-    {
       "matchManagers": ["buildkite", "npm", "nvm"],
 
       "commitMessageExtra": "{{newValue}}",
       "commitMessageTopic": "{{depName}}"
+    },
+    {
+      "matchDepTypes": ["dependencies"],
+      "matchManagers": ["npm"],
+
+      "semanticCommitType": "fix"
     },
     {
       "excludePackageNames": ["braid-design-system", "sku", "skuba"],


### PR DESCRIPTION
Per Renovate's doco:

> Renovate will evaluate all `packageRules` and not stop once it gets a
> first match. Therefore, you should order your `packageRules` in order
> of importance so that later rules can override settings from earlier
> rules if necessary.

https://docs.renovatebot.com/configuration-options/#packagerules