### PR TITLE
non-critical: Disable `@types/node` majors

### DIFF
--- a/non-critical.json
+++ b/non-critical.json
@@ -14,6 +14,13 @@
   },
   "packageRules": [
     {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@types/node"],
+      "matchUpdateTypes": ["major"],
+
+      "enabled": false
+    },
+    {
       "excludePackageNames": ["seek-jobs/gantry"],
       "matchUpdateTypes": [
         "bump",


### PR DESCRIPTION
`@types/node@16` is currently causing some pain.