### PR TITLE
Disable Docker major upgrades on non-critical

### DIFF
--- a/non-critical.json
+++ b/non-critical.json
@@ -7,7 +7,8 @@
     ":semanticCommits",
     ":timezone(Australia/Melbourne)",
     "preview:buildkite",
-    "preview:dockerCompose"
+    "preview:dockerCompose",
+    "docker:disableMajor"
   ],
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
Rynovate's new favourite activity is to upgrade all our non-critical repos to Node 16. Our other presets extend `docker:disableMajor` but it's missing here for some reason.
