### PR TITLE
Exclude aws-sdk from dev dependency run

### DIFF
--- a/default.json
+++ b/default.json
@@ -57,10 +57,11 @@
       "schedule": "before 3:00 am every 2 weeks on Tuesday"
     },
     {
-      "excludePackageNames": ["braid-design-system", "sku", "skuba"],
+      "excludePackageNames": ["aws-sdk", "braid-design-system", "sku", "skuba"],
       "excludePackagePatterns": [
         "^@?seek",
         "seek$",
+        "^@aws-sdk/",
         "^@types/",
         "^@vanilla-extract/"
       ],
@@ -119,7 +120,6 @@
       "schedule": "after 3:00 am and before 6:00 am every weekday"
     },
     {
-      "matchDepTypes": ["dependencies"],
       "matchManagers": ["npm"],
       "matchPackageNames": ["aws-sdk"],
       "matchPackagePatterns": ["^@aws-sdk/"],


### PR DESCRIPTION
This is causing issues because AWS SDK V3 users typically have `@aws-sdk/types` in their dev dependencies and other `@aws-sdk` packages in their dependencies. Renovate is bumping the former by itself which leads to broken builds.

Instead, just have all aws-sdk packages on a monthly schedule.