### PR TITLE
Unconfuse aws-sdk group and lockfile maintenance

### DIFF
--- a/default.json
+++ b/default.json
@@ -123,6 +123,7 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["aws-sdk"],
       "matchPackagePatterns": ["^@aws-sdk/"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
 
       "commitMessageExtra": "",
       "groupName": "aws-sdk",


### PR DESCRIPTION
Without this, we're getting weird combined PRs like so:

```
deps: lock file maintenance aws-sdk
```