### PR TITLE
Disable pino-pretty@7 renovation

### DIFF
--- a/default.json
+++ b/default.json
@@ -46,6 +46,12 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["pino-pretty"],
+
+      "allowedVersions": "< 7"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@types/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
 


### PR DESCRIPTION
pino-pretty@7 requires pino@7, which has not been released on its stable channel yet.