### PR TITLE
Disable ESLint v8 renovation

### DIFF
--- a/default.json
+++ b/default.json
@@ -47,7 +47,6 @@
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["eslint"],
-      "matchUpdateTypes": ["major"],
 
       "allowedVersions": "< 8"
     },


### PR DESCRIPTION
It's very unlikely that a SEEK project will be able to land this change given that `eslint-config-seek` is not ready yet.

See seek-oss/eslint-config-seek#62.