### PR TITLE
Add stability days

### DIFF
--- a/default.json
+++ b/default.json
@@ -140,7 +140,8 @@
       "commitMessageExtra": "",
       "groupName": "aws-sdk",
       "recreateClosed": true,
-      "schedule": "after 3:00 am and before 6:00 am on the first day of the month"
+      "schedule": "after 3:00 am and before 6:00 am on the first day of the month",
+      "stabilityDays": 0
     },
     {
       "matchDepTypes": ["devDependencies"],

--- a/default.json
+++ b/default.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     ":prHourlyLimit4",
+    ":prNotPending",
     ":rebaseStalePrs",
     ":renovatePrefix",
     ":semanticCommits",

--- a/default.json
+++ b/default.json
@@ -218,5 +218,6 @@
   "rangeStrategy": "auto",
   "schedule": "after 3:00 am and before 6:00 am on Monday and Friday",
   "semanticCommitScope": "",
-  "semanticCommitType": "deps"
+  "semanticCommitType": "deps",
+  "stabilityDays": 3
 }

--- a/default.json
+++ b/default.json
@@ -1,5 +1,6 @@
 {
   "extends": [
+    ":dependencyDashboard",
     ":prHourlyLimit4",
     ":prNotPending",
     ":rebaseStalePrs",

--- a/default.json
+++ b/default.json
@@ -129,7 +129,8 @@
       "matchPackagePatterns": ["^@?seek", "seek$", "^@vanilla-extract/"],
 
       "prPriority": 98,
-      "schedule": "after 3:00 am and before 6:00 am every weekday"
+      "schedule": "after 3:00 am and before 6:00 am every weekday",
+      "stabilityDays": 0
     },
     {
       "matchManagers": ["npm"],
@@ -153,7 +154,8 @@
         "@seek/indie-cardib-types"
       ],
 
-      "automerge": true
+      "automerge": true,
+      "stabilityDays": 0
     },
     {
       "matchDepTypes": ["devDependencies"],
@@ -165,14 +167,16 @@
         "@seek/indie-cardib-types"
       ],
 
-      "schedule": "before 3:00 am every weekday"
+      "schedule": "before 3:00 am every weekday",
+      "stabilityDays": 0
     },
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["sku", "skuba"],
       "matchUpdateTypes": ["patch"],
 
-      "automerge": true
+      "automerge": true,
+      "stabilityDays": 0
     },
     {
       "matchManagers": ["npm"],
@@ -180,7 +184,8 @@
       "matchUpdateTypes": ["minor", "patch"],
 
       "automerge": true,
-      "schedule": "before 3:00 am every weekday"
+      "schedule": "before 3:00 am every weekday",
+      "stabilityDays": 0
     },
     {
       "matchPackageNames": ["react-relay"],


### PR DESCRIPTION
Help prevent malicious npm package updates - add default stabilityday delay of 3 for non aws-sdk/seek internal packages

[Option info](https://docs.renovatebot.com/configuration-options/#stabilitydays)

Added "dependency dashboard" issue.
As mentioned in the docs, without this, it is impossible to see future PRs that are delayed due to stabilityDays.

Pics:

<img width="997" alt="Screen Shot 2021-12-13 at 3 50 48 pm" src="https://user-images.githubusercontent.com/74513123/145754736-df7966b5-9064-4fb1-b86d-7b7997c71d8e.png">
<img width="862" alt="Screen Shot 2021-12-13 at 3 50 30 pm" src="https://user-images.githubusercontent.com/74513123/145754741-14b22356-ee10-4dbe-8da8-01885295de79.png">


