### PR TITLE
add StabilityDays 3

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,11 +1,12 @@
 {
   "extends": [
+    ":dependencyDashboard",
     ":prHourlyLimit4",
+    ":prNotPending",
     ":rebaseStalePrs",
     ":renovatePrefix",
     ":semanticCommits",
     ":timezone(Australia/Melbourne)",
-    ":updateNotScheduled",
     "preview:buildkite",
     "preview:dockerCompose",
     "docker:disableMajor",
@@ -17,13 +18,11 @@
   "packageRules": [
     {
       "matchManagers": ["buildkite", "gomod", "npm", "nvm"],
-
       "commitMessageExtra": "{{newValue}}",
       "commitMessageTopic": "{{depName}}"
     },
     {
       "matchManagers": ["gomod"],
-
       "digest": {
         "commitMessageExtra": "",
         "groupName": "gomod digests",
@@ -34,34 +33,29 @@
     {
       "matchDepTypes": ["dependencies"],
       "matchManagers": ["npm"],
-
       "semanticCommitType": "fix"
     },
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["@types/node"],
       "matchUpdateTypes": ["major"],
-
       "enabled": false
     },
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["eslint"],
-
       "allowedVersions": "< 8"
     },
     {
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@types/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
-
       "automerge": true
     },
     {
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@types/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
-
       "commitMessageExtra": "",
       "groupName": "npm definitely typed",
       "prPriority": 99,
@@ -80,7 +74,6 @@
       "matchDepTypes": ["devDependencies"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major", "minor", "patch"],
-
       "commitMessageExtra": "",
       "groupName": "npm dev dependencies",
       "recreateClosed": true,
@@ -97,7 +90,6 @@
       "matchDepTypes": ["peerDependencies"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major", "minor", "patch"],
-
       "commitMessageExtra": "",
       "groupName": "npm peer dependencies",
       "recreateClosed": true,
@@ -106,7 +98,6 @@
     {
       "excludePackagePatterns": ["^seek-jobs/", "^seek-oss/"],
       "matchManagers": ["buildkite"],
-
       "additionalBranchPrefix": "",
       "commitMessageExtra": "",
       "groupName": "buildkite plugins",
@@ -115,7 +106,6 @@
     },
     {
       "matchManagers": ["docker-compose", "dockerfile"],
-
       "commitMessageExtra": "",
       "group": {
         "commitMessageTopic": "{{groupName}}"
@@ -127,20 +117,22 @@
     {
       "matchPackageNames": ["braid-design-system", "sku", "skuba"],
       "matchPackagePatterns": ["^@?seek", "seek$", "^@vanilla-extract/"],
-
       "prPriority": 98,
-      "schedule": "after 3:00 am and before 6:00 am every weekday"
+      "schedule": "after 3:00 am and before 6:00 am every weekday",
+      "stabilityDays": 0,
+      "updateNotScheduled": true
     },
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["aws-sdk"],
       "matchPackagePatterns": ["^@aws-sdk/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
-
       "commitMessageExtra": "",
       "groupName": "aws-sdk",
       "recreateClosed": true,
-      "schedule": "after 3:00 am and before 6:00 am on the first day of the month"
+      "schedule": "after 3:00 am and before 6:00 am on the first day of the month",
+      "stabilityDays": 0,
+      "updateNotScheduled": true
     },
     {
       "matchDepTypes": ["devDependencies"],
@@ -151,8 +143,9 @@
         "@seek/ie-shared-types",
         "@seek/indie-cardib-types"
       ],
-
-      "automerge": true
+      "automerge": true,
+      "stabilityDays": 0,
+      "updateNotScheduled": true
     },
     {
       "matchDepTypes": ["devDependencies"],
@@ -163,50 +156,48 @@
         "@seek/ie-shared-types",
         "@seek/indie-cardib-types"
       ],
-
-      "schedule": "before 3:00 am every weekday"
+      "schedule": "before 3:00 am every weekday",
+      "stabilityDays": 0,
+      "updateNotScheduled": true
     },
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["sku", "skuba"],
       "matchUpdateTypes": ["patch"],
-
-      "automerge": true
+      "automerge": true,
+      "stabilityDays": 0,
+      "updateNotScheduled": true
     },
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["@seek/indie-api-types"],
       "matchUpdateTypes": ["minor", "patch"],
-
       "automerge": true,
-      "schedule": "before 3:00 am every weekday"
+      "schedule": "before 3:00 am every weekday",
+      "stabilityDays": 0,
+      "updateNotScheduled": true
     },
     {
       "matchPackageNames": ["react-relay"],
       "matchPackagePatterns": ["^relay-"],
-
       "groupName": "relay",
       "recreateClosed": true
     },
     {
       "matchUpdateTypes": ["lockFileMaintenance"],
-
       "automerge": true
     },
     {
       "matchUpdateTypes": ["lockFileMaintenance"],
-
       "prPriority": 99,
       "schedule": "before 3:00 am every 2 weeks on Wednesday"
     },
     {
       "matchUpdateTypes": ["pin"],
-
       "automerge": true
     },
     {
       "matchUpdateTypes": ["pin"],
-
       "prPriority": 99,
       "schedule": "before 3:00 am every weekday"
     }
@@ -218,5 +209,7 @@
   "rangeStrategy": "auto",
   "schedule": "after 3:00 am and before 6:00 am on Monday and Friday",
   "semanticCommitScope": "",
-  "semanticCommitType": "deps"
+  "semanticCommitType": "deps",
+  "stabilityDays": 3,
+  "updateNotScheduled": false
 }

--- a/default.json
+++ b/default.json
@@ -179,6 +179,7 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["sku", "skuba"],
       "matchUpdateTypes": ["patch"],
+
       "automerge": true,
       "stabilityDays": 0,
       "updateNotScheduled": true

--- a/default.json
+++ b/default.json
@@ -18,11 +18,13 @@
   "packageRules": [
     {
       "matchManagers": ["buildkite", "gomod", "npm", "nvm"],
+
       "commitMessageExtra": "{{newValue}}",
       "commitMessageTopic": "{{depName}}"
     },
     {
       "matchManagers": ["gomod"],
+
       "digest": {
         "commitMessageExtra": "",
         "groupName": "gomod digests",
@@ -33,29 +35,34 @@
     {
       "matchDepTypes": ["dependencies"],
       "matchManagers": ["npm"],
+
       "semanticCommitType": "fix"
     },
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["@types/node"],
       "matchUpdateTypes": ["major"],
+
       "enabled": false
     },
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["eslint"],
+
       "allowedVersions": "< 8"
     },
     {
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@types/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
+
       "automerge": true
     },
     {
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@types/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
+
       "commitMessageExtra": "",
       "groupName": "npm definitely typed",
       "prPriority": 99,
@@ -74,6 +81,7 @@
       "matchDepTypes": ["devDependencies"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major", "minor", "patch"],
+
       "commitMessageExtra": "",
       "groupName": "npm dev dependencies",
       "recreateClosed": true,
@@ -90,6 +98,7 @@
       "matchDepTypes": ["peerDependencies"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major", "minor", "patch"],
+
       "commitMessageExtra": "",
       "groupName": "npm peer dependencies",
       "recreateClosed": true,
@@ -98,6 +107,7 @@
     {
       "excludePackagePatterns": ["^seek-jobs/", "^seek-oss/"],
       "matchManagers": ["buildkite"],
+
       "additionalBranchPrefix": "",
       "commitMessageExtra": "",
       "groupName": "buildkite plugins",
@@ -106,6 +116,7 @@
     },
     {
       "matchManagers": ["docker-compose", "dockerfile"],
+
       "commitMessageExtra": "",
       "group": {
         "commitMessageTopic": "{{groupName}}"
@@ -117,6 +128,7 @@
     {
       "matchPackageNames": ["braid-design-system", "sku", "skuba"],
       "matchPackagePatterns": ["^@?seek", "seek$", "^@vanilla-extract/"],
+
       "prPriority": 98,
       "schedule": "after 3:00 am and before 6:00 am every weekday",
       "stabilityDays": 0,
@@ -127,6 +139,7 @@
       "matchPackageNames": ["aws-sdk"],
       "matchPackagePatterns": ["^@aws-sdk/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
+
       "commitMessageExtra": "",
       "groupName": "aws-sdk",
       "recreateClosed": true,
@@ -143,6 +156,7 @@
         "@seek/ie-shared-types",
         "@seek/indie-cardib-types"
       ],
+
       "automerge": true,
       "stabilityDays": 0,
       "updateNotScheduled": true
@@ -156,6 +170,7 @@
         "@seek/ie-shared-types",
         "@seek/indie-cardib-types"
       ],
+
       "schedule": "before 3:00 am every weekday",
       "stabilityDays": 0,
       "updateNotScheduled": true
@@ -172,6 +187,7 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["@seek/indie-api-types"],
       "matchUpdateTypes": ["minor", "patch"],
+
       "automerge": true,
       "schedule": "before 3:00 am every weekday",
       "stabilityDays": 0,
@@ -180,24 +196,29 @@
     {
       "matchPackageNames": ["react-relay"],
       "matchPackagePatterns": ["^relay-"],
+
       "groupName": "relay",
       "recreateClosed": true
     },
     {
       "matchUpdateTypes": ["lockFileMaintenance"],
+
       "automerge": true
     },
     {
       "matchUpdateTypes": ["lockFileMaintenance"],
+
       "prPriority": 99,
       "schedule": "before 3:00 am every 2 weeks on Wednesday"
     },
     {
       "matchUpdateTypes": ["pin"],
+
       "automerge": true
     },
     {
       "matchUpdateTypes": ["pin"],
+
       "prPriority": 99,
       "schedule": "before 3:00 am every weekday"
     }


### PR DESCRIPTION
Help prevent malicious npm package updates - add default stabilityday delay of 3 for non aws-sdk/seek internal packages.

Have tested this config for ~3 weeks in candiman's cm-search-api.

[Option info](https://docs.renovatebot.com/configuration-options/#stabilitydays)

* Added "dependency dashboard" issue. As mentioned in the docs, without this, it is impossible to see future PRs that are delayed due to stabilityDays. It's also a useful way of manually triggering PR creation.
* When updateNotScheduled  is set to true (default previously) - PRs could be updated out of schedule. This caused the noisy dev deps group to be constantly updated, resetting the stabilityDays. Only enable updatenotscheduled for dependency groups with stabilitydays 0

Pics:

<img width="997" alt="Screen Shot 2021-12-13 at 3 50 48 pm" src="https://user-images.githubusercontent.com/74513123/145754736-df7966b5-9064-4fb1-b86d-7b7997c71d8e.png">
<img width="862" alt="Screen Shot 2021-12-13 at 3 50 30 pm" src="https://user-images.githubusercontent.com/74513123/145754741-14b22356-ee10-4dbe-8da8-01885295de79.png">


