### PR TITLE
Enable Dependency Dashboard on other presets

### DIFF
--- a/non-critical.json
+++ b/non-critical.json
@@ -1,5 +1,6 @@
 {
   "extends": [
+    ":dependencyDashboard",
     ":prHourlyLimit2",
     ":prNotPending",
     ":rebaseStalePrs",

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -1,5 +1,6 @@
 {
   "extends": [
+    ":dependencyDashboard",
     ":prHourlyLimit4",
     ":rebaseStalePrs",
     ":renovatePrefix",


### PR DESCRIPTION
These seem generally useful and don't seem to present any notification spam once you unsubscribe from the issues.