### PR TITLE
Group auxiliary Apollo Server packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -160,6 +160,13 @@
       "updateNotScheduled": true
     },
     {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["apollo-server-plugin-base", "apollo-server-types"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+
+      "groupName": "apollo-server monorepo"
+    },
+    {
       "matchDepTypes": ["devDependencies"],
       "matchManagers": ["npm"],
       "matchPackageNames": [


### PR DESCRIPTION
This isn't handled by the Apollo GraphQL nor monorepo group presets.

https://docs.renovatebot.com/presets-group/#groupallapollographql