### PR TITLE
default: Expedite SEEK Buildkite plugins

### DIFF
--- a/default.json
+++ b/default.json
@@ -127,6 +127,19 @@
       "schedule": "after 3:00 am and before 6:00 am every 2 weeks on Wednesday"
     },
     {
+      "matchManagers": ["buildkite"],
+      "matchPackagePatterns": ["^seek-jobs/", "^seek-oss/"],
+
+      "stabilityDays": 0,
+      "updateNotScheduled": true
+    },
+    {
+      "matchManagers": ["buildkite"],
+      "matchPackageNames": ["seek-jobs/gantry"],
+
+      "schedule": "before 6:00 pm every weekday"
+    },
+    {
       "matchManagers": ["docker-compose", "dockerfile"],
 
       "commitMessageExtra": "",


### PR DESCRIPTION
This was missed in #54 and has led to us missing Gantry PRs.