### PR TITLE
default: Tweak Gantry rule

### DIFF
--- a/default.json
+++ b/default.json
@@ -127,19 +127,6 @@
       "schedule": "after 3:00 am and before 6:00 am every 2 weeks on Wednesday"
     },
     {
-      "matchManagers": ["buildkite"],
-      "matchPackagePatterns": ["^seek-jobs/", "^seek-oss/"],
-
-      "stabilityDays": 0,
-      "updateNotScheduled": true
-    },
-    {
-      "matchManagers": ["buildkite"],
-      "matchPackageNames": ["seek-jobs/gantry"],
-
-      "schedule": "before 6:00 pm every weekday"
-    },
-    {
       "matchManagers": ["docker-compose", "dockerfile"],
 
       "commitMessageExtra": "",
@@ -158,6 +145,13 @@
       "schedule": "after 3:00 am and before 6:00 am every weekday",
       "stabilityDays": 0,
       "updateNotScheduled": true
+    },
+    {
+      "matchManagers": ["buildkite"],
+      "matchPackageNames": ["seek-jobs/gantry"],
+
+      "prCreation": "immediate",
+      "schedule": "after 3:00am and before 6:00 pm every weekday"
     },
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
#62 was overwritten by the catch-all rule with `"prPriority": 98`, which I forgot covered more than just npm dependencies.

This means that Gantry PRs should have been raised during the typical 3am–6am window. The only other thing that #54 changes was the default `prCreation` setting, and I wonder if that's broken or rate limited in some way such that Renovate never gets around to creating the PR within the window.