### PR TITLE
default: Reduce Gantry schedule

### DIFF
--- a/default.json
+++ b/default.json
@@ -151,7 +151,7 @@
       "matchPackageNames": ["seek-jobs/gantry"],
 
       "prCreation": "immediate",
-      "schedule": "after 3:00am and before 9:00 am every weekday"
+      "schedule": "after 3:00 am and before 9:00 am every weekday"
     },
     {
       "matchManagers": ["npm"],

--- a/default.json
+++ b/default.json
@@ -151,7 +151,7 @@
       "matchPackageNames": ["seek-jobs/gantry"],
 
       "prCreation": "immediate",
-      "schedule": "after 3:00am and before 6:00 pm every weekday"
+      "schedule": "after 3:00am and before 9:00 am every weekday"
     },
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
I've decided to extend this beyond the typical 3–6am window since Gantry PRs are often ones you need to action all at once, and wouldn't want to get rate limited behind other PRs.