### PR TITLE
default: Increase `branchConcurrentLimit`

### DIFF
--- a/default.json
+++ b/default.json
@@ -151,7 +151,7 @@
       "matchPackageNames": ["seek-jobs/gantry"],
 
       "prCreation": "immediate",
-      "schedule": "after 3:00 am and before 9:00 am every weekday"
+      "schedule": "after 3:00 am and before 5:00 pm every weekday"
     },
     {
       "matchManagers": ["npm"],
@@ -250,6 +250,7 @@
       "schedule": "before 3:00 am every weekday"
     }
   ],
+  "branchConcurrentLimit": 8,
   "commitMessageAction": "",
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 3,


### PR DESCRIPTION
This defaults to `prConcurrentLimit`, however the `stabilityDays` configuration added in #54 can leave pending branches around which eat into this limit. With an added buffer we can ensure that Renovate still creates new branches for other updates that may be ready to be PRed.