### PR TITLE
default: Remove `prHourlyLimit`

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,7 +1,6 @@
 {
   "extends": [
     ":dependencyDashboard",
-    ":prHourlyLimit4",
     ":prNotPending",
     ":rebaseStalePrs",
     ":renovatePrefix",


### PR DESCRIPTION
This shouldn't be necessary when we have `prConcurrentLimit` and just adds another condition where Renovate may choose to skip work on a particular run.