### PR TITLE
Try to force `prCreation` for trusted deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -152,7 +152,8 @@
 
       "prCreation": "immediate",
       "schedule": "after 3:00 am and before 5:00 pm every weekday",
-      "stabilityDays": 0
+      "stabilityDays": 0,
+      "updateNotScheduled": true
     },
     {
       "matchManagers": ["npm"],

--- a/default.json
+++ b/default.json
@@ -140,6 +140,7 @@
       "matchPackageNames": ["braid-design-system", "sku", "skuba"],
       "matchPackagePatterns": ["^@?seek", "seek$", "^@vanilla-extract/"],
 
+      "prCreation": "immediate",
       "prPriority": 98,
       "schedule": "after 3:00 am and before 6:00 am every weekday",
       "stabilityDays": 0,
@@ -150,7 +151,8 @@
       "matchPackageNames": ["seek-jobs/gantry"],
 
       "prCreation": "immediate",
-      "schedule": "after 3:00 am and before 5:00 pm every weekday"
+      "schedule": "after 3:00 am and before 5:00 pm every weekday",
+      "stabilityDays": 0
     },
     {
       "matchManagers": ["npm"],
@@ -160,6 +162,7 @@
 
       "commitMessageExtra": "",
       "groupName": "aws-sdk",
+      "prCreation": "immediate",
       "recreateClosed": true,
       "schedule": "after 3:00 am and before 6:00 am on the first day of the month",
       "stabilityDays": 0,
@@ -183,6 +186,7 @@
       ],
 
       "automerge": true,
+      "prCreation": "immediate",
       "stabilityDays": 0,
       "updateNotScheduled": true
     },
@@ -196,6 +200,7 @@
         "@seek/indie-cardib-types"
       ],
 
+      "prCreation": "immediate",
       "schedule": "before 3:00 am every weekday",
       "stabilityDays": 0,
       "updateNotScheduled": true
@@ -206,6 +211,7 @@
       "matchUpdateTypes": ["patch"],
 
       "automerge": true,
+      "prCreation": "immediate",
       "stabilityDays": 0,
       "updateNotScheduled": true
     },
@@ -215,6 +221,7 @@
       "matchUpdateTypes": ["minor", "patch"],
 
       "automerge": true,
+      "prCreation": "immediate",
       "schedule": "before 3:00 am every weekday",
       "stabilityDays": 0,
       "updateNotScheduled": true


### PR DESCRIPTION
We seem to be receiving far fewer Renovate PRs as a result of #54. This includes SEEK deps where I've had to manually go to Dependency Dashboards to force their creation.

My working theory is that a deferred `prCreation` means that Renovate has to take additional passes at a given branch to get it PRed, and that may be leading to some internal rate limiting. Immediate PR creation means that the work can be bundled alongside the initial commit and branch creation.

This doesn't help matters where we need to enforce `stabilityDays`, but may restore some reliability for trusted deps.