### PR TITLE
Bump `branchConcurrentLimit` again :(

### DIFF
--- a/default.json
+++ b/default.json
@@ -256,7 +256,7 @@
       "schedule": "before 3:00 am every weekday"
     }
   ],
-  "branchConcurrentLimit": 8,
+  "branchConcurrentLimit": 12,
   "commitMessageAction": "",
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 3,


### PR DESCRIPTION
I'm observing some frontend repos are not getting SEEK dependency upgrades because they are blocked behind pending branches. Unfortunately `branchConcurrentLimit` is a repository-level option so we can't customise its behaviour based on package rules.