### PR TITLE
Exclude Serverless packages from dev deps group

### DIFF
--- a/default.json
+++ b/default.json
@@ -236,6 +236,13 @@
       "recreateClosed": true
     },
     {
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^serverless-"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+
+      "groupName": "serverless"
+    },
+    {
       "matchUpdateTypes": ["lockFileMaintenance"],
 
       "automerge": true

--- a/default.json
+++ b/default.json
@@ -240,8 +240,6 @@
       "matchPackagePatterns": ["^serverless-"],
       "matchPackageNames": ["serverless"],
       "matchUpdateTypes": ["major", "minor", "patch"],
-
-      "groupName": "serverless"
     },
     {
       "matchUpdateTypes": ["lockFileMaintenance"],

--- a/default.json
+++ b/default.json
@@ -238,6 +238,7 @@
     {
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["^serverless-"],
+      "matchPackageNames": ["serverless"],
       "matchUpdateTypes": ["major", "minor", "patch"],
 
       "groupName": "serverless"

--- a/default.json
+++ b/default.json
@@ -87,7 +87,8 @@
         "seek$",
         "^@aws-sdk/",
         "^@types/",
-        "^@vanilla-extract/"
+        "^@vanilla-extract/",
+        "^serverless"
       ],
       "matchDepTypes": ["devDependencies"],
       "matchManagers": ["npm"],
@@ -234,12 +235,6 @@
 
       "groupName": "relay",
       "recreateClosed": true
-    },
-    {
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^serverless-"],
-      "matchPackageNames": ["serverless"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
     },
     {
       "matchUpdateTypes": ["lockFileMaintenance"],


### PR DESCRIPTION
Serverless updates and Serverless plugins have the potential to completely change the runtime behaviour of our Lambdas so we should not bundle them together with other dev dependency updates which "typically" do not affect the runtime