### PR TITLE
Replace "/" from Renovate Branch Prefix with "--" to be URL Safe

### DIFF
--- a/default.json
+++ b/default.json
@@ -260,6 +260,7 @@
     }
   ],
   "branchConcurrentLimit": 12,
+  "branchPrefix": "renovate--",
   "commitMessageAction": "",
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 3,

--- a/default.json
+++ b/default.json
@@ -3,7 +3,6 @@
     ":dependencyDashboard",
     ":prNotPending",
     ":rebaseStalePrs",
-    ":renovatePrefix",
     ":semanticCommits",
     ":timezone(Australia/Melbourne)",
     "preview:buildkite",


### PR DESCRIPTION
Branches can be used as identifiers for things like preview environments.
This can mean that the branch name appears in URLs, either as subdomains, paths or query parameters.

- `cool-feature.example.com`
- `example.com/cool-feature`
- `example.com/path?version=cool-feature`

In these cases it's nice to have URLs with limited special characters.

**Current**
Currently renovate branches have `/` added which results in URLs like:

- `renovate%2Fcool-feature.example.com`
- `example.com/renovate%2Fcool-feature`
- `example.com/path?version=renovate%2Fcool-feature`


**With Change**

With this change it'll instead use `--`:

- `renovate--cool-feature.example.com`
- `example.com/renovate--cool-feature`
- `example.com/path?version=renovate--cool-feature`

**Change**

Default for Branch Prefix is `renovate/`
This PR changes is to `renovate--`

**Precedence**

This aligns to the SEEK Renovate config that sets the value to the same: https://github.com/seek-oss/renovate-config-seek/blob/eb02ac2d5b72828c9365020a5b44f37ab5921323/package.json#L28

This has been raised previously and was closed: https://github.com/seek-oss/rynovate/pull/7 though allowed re-open if it's still an issue which I believe it is.