### PR TITLE
Formalise branch prefix as `renovate-`

### DIFF
--- a/default.json
+++ b/default.json
@@ -259,7 +259,7 @@
     }
   ],
   "branchConcurrentLimit": 12,
-  "branchPrefix": "renovate--",
+  "branchPrefix": "renovate-",
   "commitMessageAction": "",
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 3,


### PR DESCRIPTION
`renovate--` appears to be normalised to `renovate-` by Renovate now. This formalises the change so we aren't beholden to Renovate's implementation details which could flip back to respecting `renovate--` in future.

Also see seek-oss/renovate-config-seek#19