### PR TITLE
move profile packages to different package rules

### DIFF
--- a/default.json
+++ b/default.json
@@ -182,7 +182,6 @@
       "matchPackageNames": [
         "@seek/backoffice-access",
         "@seek/ca-graphql-schema",
-        "@seek/candidate-data-contracts",
         "@seek/hirer-jobs-types",
         "@seek/ie-shared-types",
         "@seek/indie-cardib-types"
@@ -199,7 +198,6 @@
       "matchPackageNames": [
         "@seek/backoffice-access",
         "@seek/ca-graphql-schema",
-        "@seek/candidate-data-contracts",
         "@seek/hirer-jobs-types",
         "@seek/ie-shared-types",
         "@seek/indie-cardib-types"
@@ -219,7 +217,12 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@seek/indie-api-types", "@seek/indie-mocks"],
+      "matchPackageNames": [
+        "@seek/indie-api-types",
+        "@seek/indie-mocks",
+        "@seek/candidate-data-contracts",
+        "@seek/apply-pipeline-contracts",
+        "@seek/blobstore-consumer-sdk"],
       "matchUpdateTypes": ["minor", "patch"],
 
       "automerge": true,

--- a/default.json
+++ b/default.json
@@ -218,11 +218,11 @@
     {
       "matchManagers": ["npm"],
       "matchPackageNames": [
-        "@seek/indie-api-types",
-        "@seek/indie-mocks",
-        "@seek/candidate-data-contracts",
         "@seek/apply-pipeline-contracts",
-        "@seek/blobstore-consumer-sdk"
+        "@seek/blobstore-consumer-sdk",
+        "@seek/candidate-data-contracts",
+        "@seek/indie-api-types",
+        "@seek/indie-mocks"
       ],
       "matchUpdateTypes": ["minor", "patch"],
 

--- a/default.json
+++ b/default.json
@@ -222,7 +222,8 @@
         "@seek/indie-mocks",
         "@seek/candidate-data-contracts",
         "@seek/apply-pipeline-contracts",
-        "@seek/blobstore-consumer-sdk"],
+        "@seek/blobstore-consumer-sdk"
+      ],
       "matchUpdateTypes": ["minor", "patch"],
 
       "automerge": true,


### PR DESCRIPTION
## Purpose

There are too many Renovate PRs and it is getting hard and hard to keep merging it. Currently we have around 255 renovate PRs opened for profile and apply repositories.

Moving this repos to a an auto-merge for minor and patches changes, it will help profile and apply services to keep the number of PRs opened smaller.