### PR TITLE
Revert range strategy to "replace"

### DIFF
--- a/default.json
+++ b/default.json
@@ -268,7 +268,7 @@
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,
-  "rangeStrategy": "auto",
+  "rangeStrategy": "replace",
   "schedule": "after 3:00 am and before 6:00 am on Monday and Friday",
   "semanticCommitScope": "",
   "semanticCommitType": "deps",

--- a/default.json
+++ b/default.json
@@ -15,6 +15,11 @@
   },
   "packageRules": [
     {
+      "matchDepTypes": ["peerDependencies"],
+
+      "rangeStrategy": "widen"
+    },
+    {
       "matchManagers": ["buildkite", "gomod", "npm", "nvm"],
 
       "commitMessageExtra": "{{newValue}}",

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -111,7 +111,7 @@
   "postUpdateOptions": ["yarnDedupeHighest"],
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,
-  "rangeStrategy": "auto",
+  "rangeStrategy": "replace",
   "schedule": "after 3:00 am and before 6:00 am on Monday and Friday",
   "semanticCommitScope": "",
   "semanticCommitType": "deps"

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -16,6 +16,11 @@
   },
   "packageRules": [
     {
+      "matchDepTypes": ["peerDependencies"],
+
+      "rangeStrategy": "widen"
+    },
+    {
       "matchManagers": ["buildkite", "npm", "nvm"],
 
       "commitMessageExtra": "{{newValue}}",


### PR DESCRIPTION
Per renovatebot/renovate#19800, the "auto" strategy now raises additional PRs to update dependencies in range. This is either unsuitable for our use case or bugged, as we have "lockfile update" PRs (as denoted by a `-lockfile` branch suffix) which are bumping the in-range version of a package's production dependencies. This means that e.g. `^2.0.0` gets bumped to `^2.1.0` and so on, and results in a lot of transitive noise for projects that consume the package.

I've also patched in widening of peer dependency ranges which is what "auto" was previously described as doing.

https://docs.renovatebot.com/configuration-options/#rangestrategy

https://docs.renovatebot.com/release-notes-for-major-versions/#version-35

https://github.com/renovatebot/renovate/discussions/20990