### PR TITLE
Add aws-sdk client mock group

### DIFF
--- a/default.json
+++ b/default.json
@@ -62,7 +62,7 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["aws-sdk-client-mock"],
+      "matchPackageNames": ["aws-sdk-client-mock", "aws-sdk-client-mock-jest"],
       "groupName": "aws-sdk client mock"
     },
     {

--- a/default.json
+++ b/default.json
@@ -62,6 +62,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["aws-sdk-client-mock"],
+      "groupName": "aws-sdk client mock"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["@types/faker", "faker"],
 
       "allowedVersions": "< 6"


### PR DESCRIPTION
![image](https://github.com/seek-oss/rynovate/assets/18017094/ae8aa34a-a3c1-4ab8-be96-2d1c248436a8)

aws-sdk-client-mock-jest and aws-sdk-client-mock are separate packages published in a monorepo. Will be more convenient to update them together