### PR TITLE
Add @smithy to aws-sdk group

### DIFF
--- a/default.json
+++ b/default.json
@@ -158,7 +158,7 @@
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["aws-sdk"],
-      "matchPackagePatterns": ["^@aws-sdk/"],
+      "matchPackagePatterns": ["^@aws-sdk/", "^@smithy/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
 
       "commitMessageExtra": "",


### PR DESCRIPTION
The aws-sdk moved some deps to the @smithy/ scope.

eg. @aws-sdk/smithy-client is now @smithy/smithy-client

https://github.com/aws/aws-sdk-js-v3/pull/4873