### PR TITLE
Ignore @smithy group

### DIFF
--- a/default.json
+++ b/default.json
@@ -93,6 +93,7 @@
         "^@?seek",
         "seek$",
         "^@aws-sdk/",
+        "^@smithy/",
         "^@types/",
         "^@vanilla-extract/",
         "^serverless"


### PR DESCRIPTION
@smithy is the same as @aws-sdk so it should only be seen in the same group.

<img width="840" alt="image" src="https://github.com/seek-oss/rynovate/assets/18017094/92b03ecc-6e59-40de-bc14-a4cc9f5f407f">

Does adding it to this bit stop it from being created individually?