### PR TITLE
RFC: Use `yarn-deduplicate --strategy fewer`

### DIFF
--- a/default.json
+++ b/default.json
@@ -261,7 +261,7 @@
   "branchConcurrentLimit": 12,
   "branchPrefix": "renovate-",
   "commitMessageAction": "",
-  "postUpdateOptions": ["yarnDedupeHighest"],
+  "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,
   "rangeStrategy": "replace",

--- a/non-critical.json
+++ b/non-critical.json
@@ -65,7 +65,7 @@
   "buildkite": { "additionalBranchPrefix": "", "commitMessageExtra": "" },
   "commitMessageAction": "",
   "commitMessageExtra": "",
-  "postUpdateOptions": ["yarnDedupeHighest"],
+  "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 2,
   "prNotPendingHours": 1,
   "schedule": "before 6:00 am on Monday",

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -111,7 +111,7 @@
     }
   ],
   "commitMessageAction": "",
-  "postUpdateOptions": ["yarnDedupeHighest"],
+  "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,
   "rangeStrategy": "replace",


### PR DESCRIPTION
This may smooth over lockfile maintenance without having transitive dependencies introduce duplication of e.g. AWS SDK or TypeScript type packages.

https://github.com/scinos/yarn-deduplicate#deduplication-strategies