### PR TITLE
Permit major upgrades to @koa/cors

### DIFF
--- a/default.json
+++ b/default.json
@@ -48,7 +48,6 @@
     {
       "matchUpdateTypes": ["major"],
       "matchPackageNames": ["@koa/cors"],
-      "allowedVersions": "< 6",
 
       "enabled": true
     },

--- a/default.json
+++ b/default.json
@@ -46,6 +46,13 @@
       "enabled": false
     },
     {
+      "matchUpdateTypes": ["major"],
+      "matchPackageNames": ["@koa/cors"],
+      "allowedVersions": "< 6",
+
+      "enabled": true
+    },
+    {
       "matchManagers": ["npm"],
       "matchPackageNames": ["eslint"],
 

--- a/non-critical.json
+++ b/non-critical.json
@@ -22,6 +22,13 @@
       "enabled": false
     },
     {
+      "matchUpdateTypes": ["major"],
+      "matchPackageNames": ["@koa/cors"],
+      "allowedVersions": "< 6",
+
+      "enabled": true
+    },
+    {
       "matchManagers": ["npm"],
       "matchPackageNames": ["aws-sdk-mock"],
       "allowedVersions": "!/^5.5.0$/"

--- a/non-critical.json
+++ b/non-critical.json
@@ -24,7 +24,6 @@
     {
       "matchUpdateTypes": ["major"],
       "matchPackageNames": ["@koa/cors"],
-      "allowedVersions": "< 6",
 
       "enabled": true
     },

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -60,7 +60,6 @@
     {
       "matchUpdateTypes": ["major"],
       "matchPackageNames": ["@koa/cors"],
-      "allowedVersions": "< 6",
 
       "enabled": true
     },

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -58,6 +58,13 @@
       "enabled": false
     },
     {
+      "matchUpdateTypes": ["major"],
+      "matchPackageNames": ["@koa/cors"],
+      "allowedVersions": "< 6",
+
+      "enabled": true
+    },
+    {
       "excludePackagePatterns": ["^seek-jobs/", "^seek-oss/"],
       "matchManagers": ["buildkite"],
 


### PR DESCRIPTION
These can be removed once we revert #96.

https://nvd.nist.goiv/vuln/detail/CVE-2023-49803