### PR TITLE
Disable renovation on dd-trace >= 4.21

### DIFF
--- a/default.json
+++ b/default.json
@@ -71,6 +71,12 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["dd-trace"],
+
+      "allowedVersions": "< 4.21"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@types/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
 

--- a/non-critical.json
+++ b/non-critical.json
@@ -34,6 +34,12 @@
       "allowedVersions": "< 6"
     },
     {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["dd-trace"],
+
+      "allowedVersions": "< 4.21"
+    },
+    {
       "excludePackageNames": ["seek-jobs/gantry"],
       "matchUpdateTypes": [
         "bump",

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -53,6 +53,12 @@
       "allowedVersions": "< 6"
     },
     {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["dd-trace"],
+
+      "allowedVersions": "< 4.21"
+    },
+    {
       "excludePackageNames": ["@koa/cors", "@seek/ie-logging"],
       "matchUpdateTypes": ["major"],
 


### PR DESCRIPTION
We can revert once DataDog/dd-trace-js#3887 is fixed.