### PR TITLE
RFC: Wait longer before renovating `dd-trace`

### DIFF
--- a/default.json
+++ b/default.json
@@ -49,6 +49,7 @@
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["dd-trace"],
+      "matchUpdateTypes": ["major", "minor"],
 
       "minimumReleaseAge": "14 days"
     },

--- a/default.json
+++ b/default.json
@@ -48,6 +48,12 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["dd-trace"],
+
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["eslint"],
 
       "allowedVersions": "< 8"

--- a/non-critical.json
+++ b/non-critical.json
@@ -42,6 +42,7 @@
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["dd-trace"],
+      "matchUpdateTypes": ["major", "minor"],
 
       "allowedVersions": "< 4.21"
     },

--- a/non-critical.json
+++ b/non-critical.json
@@ -26,6 +26,7 @@
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["dd-trace"],
+      "matchUpdateTypes": ["major", "minor"],
 
       "minimumReleaseAge": "14 days"
     },
@@ -42,7 +43,6 @@
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["dd-trace"],
-      "matchUpdateTypes": ["major", "minor"],
 
       "allowedVersions": "< 4.21"
     },

--- a/non-critical.json
+++ b/non-critical.json
@@ -25,6 +25,12 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["dd-trace"],
+
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackageNames": ["aws-sdk-mock"],
       "allowedVersions": "!/^5.5.0$/"
     },

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -65,6 +65,12 @@
       "enabled": false
     },
     {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["dd-trace"],
+
+      "minimumReleaseAge": "14 days"
+    },
+    {
       "excludePackagePatterns": ["^seek-jobs/", "^seek-oss/"],
       "matchManagers": ["buildkite"],
 

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -67,6 +67,7 @@
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["dd-trace"],
+      "matchUpdateTypes": ["major", "minor"],
 
       "minimumReleaseAge": "14 days"
     },


### PR DESCRIPTION
We have lower confidence in new versions of this package; also see #99.

@samchungy notes that this also delays us upgrading from a bad version to a fixed one.