### PR TITLE
Revert #49

### DIFF
--- a/default.json
+++ b/default.json
@@ -48,12 +48,6 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["eslint"],
-
-      "allowedVersions": "< 8"
-    },
-    {
-      "matchManagers": ["npm"],
       "matchPackageNames": ["aws-sdk-mock"],
 
       "allowedVersions": "!/^5.5.0$/"


### PR DESCRIPTION
`eslint-config-seek` now supports ESLint v8:

https://github.com/seek-oss/eslint-config-seek/blob/f09a8ce60b4d33371f1b51c50f8e9b4ac2681e2e/package.json#L46