### PR TITLE
Re-enable renovation on dd-trace > 4.21

### DIFF
--- a/default.json
+++ b/default.json
@@ -72,12 +72,6 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["dd-trace"],
-
-      "allowedVersions": "< 4.21"
-    },
-    {
-      "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@types/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
 

--- a/default.json
+++ b/default.json
@@ -72,6 +72,12 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchPackageNames": ["dd-trace"],
+
+      "allowedVersions": "!/^4.21.0$/"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@types/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
 

--- a/non-critical.json
+++ b/non-critical.json
@@ -41,12 +41,6 @@
       "allowedVersions": "< 6"
     },
     {
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["dd-trace"],
-
-      "allowedVersions": "< 4.21"
-    },
-    {
       "excludePackageNames": ["seek-jobs/gantry"],
       "matchUpdateTypes": [
         "bump",

--- a/non-critical.json
+++ b/non-critical.json
@@ -41,6 +41,12 @@
       "allowedVersions": "< 6"
     },
     {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["dd-trace"],
+
+      "allowedVersions": "!/^4.21.0$/"
+    },
+    {
       "excludePackageNames": ["seek-jobs/gantry"],
       "matchUpdateTypes": [
         "bump",

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -53,6 +53,12 @@
       "allowedVersions": "< 6"
     },
     {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["dd-trace"],
+
+      "allowedVersions": "!/^4.21.0$/"
+    },
+    {
       "excludePackageNames": ["@koa/cors", "@seek/ie-logging"],
       "matchUpdateTypes": ["major"],
 

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -53,12 +53,6 @@
       "allowedVersions": "< 6"
     },
     {
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["dd-trace"],
-
-      "allowedVersions": "< 4.21"
-    },
-    {
       "excludePackageNames": ["@koa/cors", "@seek/ie-logging"],
       "matchUpdateTypes": ["major"],
 


### PR DESCRIPTION
This reverts commit 5ab1d2eacd88c6ed99cb082af7b82551544fbefe (#99).

https://github.com/DataDog/dd-trace-js/issues/3887#issuecomment-1867378054