### PR TITLE
Allow `@seek/indie-api-types` major through

### DIFF
--- a/default.json
+++ b/default.json
@@ -44,7 +44,8 @@
       "excludePackageNames": [
         "@koa/cors",
         "@seek/ie-logging",
-        "@seek/indie-api-types"
+        "@seek/indie-api-types",
+        "@seek/indie-mocks"
       ],
       "matchUpdateTypes": ["major"],
 

--- a/default.json
+++ b/default.json
@@ -41,7 +41,11 @@
       "semanticCommitType": "fix"
     },
     {
-      "excludePackageNames": ["@koa/cors", "@seek/ie-logging"],
+      "excludePackageNames": [
+        "@koa/cors",
+        "@seek/ie-logging",
+        "@seek/indie-api-types"
+      ],
       "matchUpdateTypes": ["major"],
 
       "enabled": false

--- a/non-critical.json
+++ b/non-critical.json
@@ -21,7 +21,8 @@
       "excludePackageNames": [
         "@koa/cors",
         "@seek/ie-logging",
-        "@seek/indie-api-types"
+        "@seek/indie-api-types",
+        "@seek/indie-mocks"
       ],
       "matchUpdateTypes": ["major"],
 

--- a/non-critical.json
+++ b/non-critical.json
@@ -18,7 +18,11 @@
       "group": { "commitMessageTopic": "{{groupName}}" }
     },
     {
-      "excludePackageNames": ["@koa/cors", "@seek/ie-logging"],
+      "excludePackageNames": [
+        "@koa/cors",
+        "@seek/ie-logging",
+        "@seek/indie-api-types"
+      ],
       "matchUpdateTypes": ["major"],
 
       "enabled": false

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -59,7 +59,11 @@
       "allowedVersions": "!/^4.21.0$/"
     },
     {
-      "excludePackageNames": ["@koa/cors", "@seek/ie-logging"],
+      "excludePackageNames": [
+        "@koa/cors",
+        "@seek/ie-logging",
+        "@seek/indie-api-types"
+      ],
       "matchUpdateTypes": ["major"],
 
       "enabled": false

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -62,7 +62,8 @@
       "excludePackageNames": [
         "@koa/cors",
         "@seek/ie-logging",
-        "@seek/indie-api-types"
+        "@seek/indie-api-types",
+        "@seek/indie-mocks"
       ],
       "matchUpdateTypes": ["major"],
 


### PR DESCRIPTION
This is tied to our AWS SDK upgrade: SEEK-Jobs/indie-api-types#911