### PR TITLE
default: Try to fix peer dependency upgrades

### DIFF
--- a/default.json
+++ b/default.json
@@ -35,7 +35,7 @@
       "semanticCommitType": "fix"
     },
     {
-      "matchDepTypes": ["dependencies"],
+      "matchDepTypes": ["dependencies", "peerDependencies"],
       "matchManagers": ["npm"],
 
       "semanticCommitType": "fix"
@@ -113,19 +113,10 @@
       "schedule": "after 3:00 am and before 6:00 am every 2 weeks on Tuesday"
     },
     {
-      "excludePackageNames": ["braid-design-system", "sku", "skuba"],
-      "excludePackagePatterns": [
-        "^@?seek",
-        "seek$",
-        "^@types/",
-        "^@vanilla-extract/"
-      ],
       "matchDepTypes": ["peerDependencies"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["major", "minor", "patch"],
 
-      "commitMessageExtra": "",
-      "groupName": "npm peer dependencies",
       "schedule": "after 3:00 am and before 6:00 am every 2 weeks on Tuesday"
     },
     {


### PR DESCRIPTION
These should generally be semantic commits as they allow consumers to install later peer dependencies without warnings. I'm not sure why we/I thought to group these beforehand.

I'm keeping the schedule aligned with dev dependencies as it's common to have a package specified under `devDependencies` and `peerDependencies`. Ideally these would even be grouped together but that's a challenge for another day.