### PR TITLE
Ignore autofix commits for SEEK-Jobs and seek-oss

### DIFF
--- a/default.json
+++ b/default.json
@@ -259,15 +259,19 @@
   "branchConcurrentLimit": 12,
   "branchPrefix": "renovate-",
   "commitMessageAction": "",
+  "gitIgnoredAuthors": [
+    "34733141+seek-oss-ci@users.noreply.github.com",
+    "87109344+buildagencygitapitoken[bot]@users.noreply.github.com"
+  ],
+  "internalChecksFilter": "strict",
+  "minimumReleaseAge": "3 days",
   "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 3,
+  "prCreation": "immediate",
   "prNotPendingHours": 1,
   "rangeStrategy": "replace",
   "schedule": "after 3:00 am and before 6:00 am on Monday and Friday",
   "semanticCommitScope": "",
   "semanticCommitType": "deps",
-  "prCreation": "immediate",
-  "minimumReleaseAge": "3 days",
-  "internalChecksFilter": "strict",
   "updateNotScheduled": false
 }

--- a/non-critical.json
+++ b/non-critical.json
@@ -78,6 +78,10 @@
   "buildkite": { "additionalBranchPrefix": "", "commitMessageExtra": "" },
   "commitMessageAction": "",
   "commitMessageExtra": "",
+  "gitIgnoredAuthors": [
+    "34733141+seek-oss-ci@users.noreply.github.com",
+    "87109344+buildagencygitapitoken[bot]@users.noreply.github.com"
+  ],
   "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 2,
   "prNotPendingHours": 1,

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -124,6 +124,10 @@
     }
   ],
   "commitMessageAction": "",
+  "gitIgnoredAuthors": [
+    "34733141+seek-oss-ci@users.noreply.github.com",
+    "87109344+buildagencygitapitoken[bot]@users.noreply.github.com"
+  ],
   "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,


### PR DESCRIPTION
The intent here is to allow Renovate to rebase a branch even if it has a skuba autofix commits that have been pushed. I think this is as simple as hardcoding the fixed bot accounts that we use for this purpose.

seek-oss/skuba#1493