### PR TITLE
Revert "Ignore autofix commits for SEEK-Jobs and seek-oss"

### DIFF
--- a/default.json
+++ b/default.json
@@ -259,19 +259,15 @@
   "branchConcurrentLimit": 12,
   "branchPrefix": "renovate-",
   "commitMessageAction": "",
-  "gitIgnoredAuthors": [
-    "34733141+seek-oss-ci@users.noreply.github.com",
-    "87109344+buildagencygitapitoken[bot]@users.noreply.github.com"
-  ],
-  "internalChecksFilter": "strict",
-  "minimumReleaseAge": "3 days",
   "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 3,
-  "prCreation": "immediate",
   "prNotPendingHours": 1,
   "rangeStrategy": "replace",
   "schedule": "after 3:00 am and before 6:00 am on Monday and Friday",
   "semanticCommitScope": "",
   "semanticCommitType": "deps",
+  "prCreation": "immediate",
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
   "updateNotScheduled": false
 }

--- a/non-critical.json
+++ b/non-critical.json
@@ -78,10 +78,6 @@
   "buildkite": { "additionalBranchPrefix": "", "commitMessageExtra": "" },
   "commitMessageAction": "",
   "commitMessageExtra": "",
-  "gitIgnoredAuthors": [
-    "34733141+seek-oss-ci@users.noreply.github.com",
-    "87109344+buildagencygitapitoken[bot]@users.noreply.github.com"
-  ],
   "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 2,
   "prNotPendingHours": 1,

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -124,10 +124,6 @@
     }
   ],
   "commitMessageAction": "",
-  "gitIgnoredAuthors": [
-    "34733141+seek-oss-ci@users.noreply.github.com",
-    "87109344+buildagencygitapitoken[bot]@users.noreply.github.com"
-  ],
   "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,


### PR DESCRIPTION
Reverts seek-oss/rynovate#108

Unfortunately, autofixes after human commits will get caught up in this due to the ignored authors only considering the last commit, not all commits on the branch: https://github.com/renovatebot/renovate/blob/132db01f14ce5c30609b8e82279ab14c9da9e8ff/lib/util/git/index.ts#L654 (thanks for the find @samchungy)