### PR TITLE
fix: rename matchPackageNames to matchDepNames as per renovate warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Disable incompatible major version upgrades for a specific package:
   packageRules: [
     {
       matchManagers: ['npm'],
-      matchPackageNames: ['your-package-name-here'],
+      matchDepNames: ['your-package-name-here'],
       matchUpdateTypes: ['major'],
 
       enabled: false,
@@ -136,7 +136,7 @@ Ignore a specific package version:
   packageRules: [
     {
       matchManagers: ['npm'],
-      matchPackageNames: ['your-package-name-here'],
+      matchDepNames: ['your-package-name-here'],
 
       allowedVersions: '!/^1\\.2\\.3$/',
     },
@@ -157,7 +157,7 @@ Ungroup a specific package that is usually grouped by the preset:
   packageRules: [
     {
       matchManagers: ['npm'],
-      matchPackageNames: ['your-package-name-here'],
+      matchDepNames: ['your-package-name-here'],
       matchUpdateTypes: ['major', 'minor', 'patch'],
 
       commitMessageExtra: '{{newValue}}',

--- a/default.json
+++ b/default.json
@@ -42,38 +42,38 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/node"],
+      "matchDepNames": ["@types/node"],
       "matchUpdateTypes": ["major"],
 
       "enabled": false
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["dd-trace"],
+      "matchDepNames": ["dd-trace"],
       "matchUpdateTypes": ["major", "minor"],
 
       "minimumReleaseAge": "14 days"
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["aws-sdk-mock"],
+      "matchDepNames": ["aws-sdk-mock"],
 
       "allowedVersions": "!/^5\\.5\\.0$/"
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["aws-sdk-client-mock", "aws-sdk-client-mock-jest"],
+      "matchDepNames": ["aws-sdk-client-mock", "aws-sdk-client-mock-jest"],
       "groupName": "aws-sdk client mock"
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/faker", "faker"],
+      "matchDepNames": ["@types/faker", "faker"],
 
       "allowedVersions": "< 6"
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["dd-trace"],
+      "matchDepNames": ["dd-trace"],
 
       "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
     },
@@ -139,7 +139,7 @@
       "schedule": "after 3:00 am and before 6:00 am every 2 weeks on Wednesday"
     },
     {
-      "matchPackageNames": ["braid-design-system", "sku", "skuba"],
+      "matchDepNames": ["braid-design-system", "sku", "skuba"],
       "matchPackagePatterns": ["^@?seek", "seek$", "^@vanilla-extract/"],
 
       "prPriority": 98,
@@ -149,7 +149,7 @@
     },
     {
       "matchManagers": ["buildkite"],
-      "matchPackageNames": ["seek-jobs/gantry"],
+      "matchDepNames": ["seek-jobs/gantry"],
 
       "schedule": "after 3:00 am and before 5:00 pm every weekday",
       "minimumReleaseAge": "0 days",
@@ -157,7 +157,7 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["aws-sdk"],
+      "matchDepNames": ["aws-sdk"],
       "matchPackagePatterns": ["^@aws-sdk/", "^@smithy/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
 
@@ -169,7 +169,7 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["apollo-server-plugin-base", "apollo-server-types"],
+      "matchDepNames": ["apollo-server-plugin-base", "apollo-server-types"],
       "matchUpdateTypes": ["major", "minor", "patch"],
 
       "groupName": "apollo-server monorepo"
@@ -177,7 +177,7 @@
     {
       "matchDepTypes": ["devDependencies"],
       "matchManagers": ["npm"],
-      "matchPackageNames": [
+      "matchDepNames": [
         "@seek/backoffice-access",
         "@seek/ca-graphql-schema",
         "@seek/hirer-jobs-types",
@@ -192,7 +192,7 @@
     {
       "matchDepTypes": ["devDependencies"],
       "matchManagers": ["npm"],
-      "matchPackageNames": [
+      "matchDepNames": [
         "@seek/backoffice-access",
         "@seek/ca-graphql-schema",
         "@seek/hirer-jobs-types",
@@ -204,7 +204,7 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["sku", "skuba"],
+      "matchDepNames": ["sku", "skuba"],
       "matchUpdateTypes": ["patch"],
 
       "automerge": true,
@@ -213,7 +213,7 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": [
+      "matchDepNames": [
         "@seek/apply-pipeline-contracts",
         "@seek/blobstore-consumer-sdk",
         "@seek/candidate-data-contracts",
@@ -228,7 +228,7 @@
       "updateNotScheduled": true
     },
     {
-      "matchPackageNames": ["react-relay"],
+      "matchDepNames": ["react-relay"],
       "matchPackagePatterns": ["^relay-"],
 
       "groupName": "relay"

--- a/non-critical.json
+++ b/non-critical.json
@@ -19,30 +19,30 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/node"],
+      "matchDepNames": ["@types/node"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["dd-trace"],
+      "matchDepNames": ["dd-trace"],
       "matchUpdateTypes": ["major", "minor"],
 
       "minimumReleaseAge": "14 days"
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["aws-sdk-mock"],
+      "matchDepNames": ["aws-sdk-mock"],
       "allowedVersions": "!/^5\\.5\\.0$/"
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/faker", "faker"],
+      "matchDepNames": ["@types/faker", "faker"],
       "allowedVersions": "< 6"
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["dd-trace"],
+      "matchDepNames": ["dd-trace"],
 
       "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
     },
@@ -62,7 +62,7 @@
     },
     {
       "matchManagers": ["buildkite"],
-      "matchPackageNames": ["seek-jobs/gantry"],
+      "matchDepNames": ["seek-jobs/gantry"],
       "commitMessageAction": "",
       "commitMessageExtra": "{{newValue}}",
       "commitMessageTopic": "{{depName}}",

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -42,19 +42,19 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["aws-sdk-mock"],
+      "matchDepNames": ["aws-sdk-mock"],
 
       "allowedVersions": "!/^5\\.5\\.0$/"
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/faker", "faker"],
+      "matchDepNames": ["@types/faker", "faker"],
 
       "allowedVersions": "< 6"
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["dd-trace"],
+      "matchDepNames": ["dd-trace"],
 
       "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
     },
@@ -69,7 +69,7 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["dd-trace"],
+      "matchDepNames": ["dd-trace"],
       "matchUpdateTypes": ["major", "minor"],
 
       "minimumReleaseAge": "14 days"
@@ -94,7 +94,7 @@
       "schedule": "after 3:00 am and before 6:00 am every 2 weeks on Wednesday"
     },
     {
-      "matchPackageNames": ["braid-design-system", "sku", "skuba"],
+      "matchDepNames": ["braid-design-system", "sku", "skuba"],
       "matchPackagePatterns": ["^@?seek", "seek$"],
 
       "prPriority": 98,


### PR DESCRIPTION

Will fix this warning

Repository problems

These problems occurred while renovating this repository. [View logs](https://developer.mend.io//github/SEEK-Jobs/bx-backends).

    WARN: Use matchDepNames instead of matchPackageNames