### PR TITLE
Exclude node fetch renovate major upgrade

### DIFF
--- a/default.json
+++ b/default.json
@@ -42,7 +42,7 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/node"],
+      "matchPackageNames": ["@types/node", "node-fetch"],
       "matchUpdateTypes": ["major"],
 
       "enabled": false

--- a/non-critical.json
+++ b/non-critical.json
@@ -19,7 +19,7 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/node"],
+      "matchPackageNames": ["@types/node", "node-fetch"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },


### PR DESCRIPTION
Excluding node-fetch from major renovate upgrade as it's requires on ESM at the moment and causes some troubles on other renovate PRs