### PR TITLE
Add serverless into aws-sdk group update

### DIFF
--- a/default.json
+++ b/default.json
@@ -164,8 +164,8 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackageNames": ["aws-sdk"],
-      "matchPackagePatterns": ["^@aws-sdk/", "^@smithy/", "serverless"],
+      "matchDepNames": ["aws-sdk", "serverless"],
+      "matchPackagePatterns": ["^@aws-sdk/", "^@smithy/"],
       "matchUpdateTypes": ["major", "minor", "patch"],
 
       "commitMessageExtra": "",

--- a/default.json
+++ b/default.json
@@ -164,12 +164,12 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchDepNames": ["aws-sdk"],
-      "matchPackagePatterns": ["^@aws-sdk/", "^@smithy/"],
+      "matchPackageNames": ["aws-sdk"],
+      "matchPackagePatterns": ["^@aws-sdk/", "^@smithy/", "serverless"],
       "matchUpdateTypes": ["major", "minor", "patch"],
 
       "commitMessageExtra": "",
-      "groupName": "aws-sdk",
+      "groupName": "aws-sdk and serverless",
       "schedule": "after 3:00 am and before 6:00 am on the first day of the month",
       "minimumReleaseAge": "0 days",
       "updateNotScheduled": true


### PR DESCRIPTION
We faced an issue in this renovate [PR](https://github.com/SEEK-Jobs/indie-graphql-op-sampler/pull/865) where the CI failed due to the `serverless` package version is not compatible with the `aws-sdk/*` packages

Suggesting to bundle them in into the same group to perform upgrade together.
We did an experiment of the renovate config in this [PR](https://github.com/SEEK-Jobs/indie-jepsen/pull/787) and it's looking good in https://github.com/SEEK-Jobs/indie-jepsen/pull/789