### PR TITLE
Adjust branchConcurrentLimit

### DIFF
--- a/default.json
+++ b/default.json
@@ -263,7 +263,7 @@
       "schedule": "before 3:00 am every weekday"
     }
   ],
-  "branchConcurrentLimit": 12,
+  "branchConcurrentLimit": 3,
   "branchPrefix": "renovate-",
   "commitMessageAction": "",
   "postUpdateOptions": ["yarnDedupeFewer"],


### PR DESCRIPTION
I see a number of branches which just go stale and constantly trigger CI runs when they get force pushed by Renovate. I don't think that it's very useful given most of our repos require our branches to be updated before being merged into the default branch.

This change limits the number of branches to the same as the pr limit.

<img width="347" alt="image" src="https://github.com/seek-oss/rynovate/assets/18017094/45fc7f7c-a23f-4e66-a08f-41db8b3bf064">
