### PR TITLE
Set `branchConcurrentLimit` to null

### DIFF
--- a/default.json
+++ b/default.json
@@ -263,7 +263,7 @@
       "schedule": "before 3:00 am every weekday"
     }
   ],
-  "branchConcurrentLimit": 3,
+  "branchConcurrentLimit": null,
   "branchPrefix": "renovate-",
   "commitMessageAction": "",
   "postUpdateOptions": ["yarnDedupeFewer"],


### PR DESCRIPTION
> `null` (default) inherits value from `prConcurrentLimit`

https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit