### PR TITLE
Omit Zod from Dev Deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -109,7 +109,8 @@
         "^@aws-sdk/",
         "^@types/",
         "^@vanilla-extract/",
-        "^serverless"
+        "^serverless",
+        "^zod"
       ],
       "matchDepTypes": ["devDependencies"],
       "matchManagers": ["npm"],


### PR DESCRIPTION
I've got an issue where I need Zod's types but not the runtime validation. But Zod's versions are inherently incompatible with other versions due to types.

When the renovate bumps the Dev dep version, it doesn't seem to change the other prod Zod deps versions. 

Eg.

Our prod dep products api package specifies zod: ^3.22.4 but the lock file still specifies 3.22.6.

The dev dep zod got bumped to 3.22.8 without touching the products version which cause TSC to be unhappy.

The ^zod prefix extends it to my zod-openapi package.