### PR TITLE
autofix aws-lambda to @types/aws-lambda

### DIFF
--- a/default.json
+++ b/default.json
@@ -266,7 +266,7 @@
       "matchManagers": ["npm"],
       "matchDepNames": ["aws-lambda"],
       "replacementName": "@types/aws-lambda",
-      "replacementVersion": "latest"
+      "replacementVersion": "8.10.140"
     }
   ],
   "branchConcurrentLimit": null,

--- a/default.json
+++ b/default.json
@@ -261,6 +261,12 @@
 
       "prPriority": 99,
       "schedule": "before 3:00 am every weekday"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepNames": ["aws-lambda"],
+      "replacementName": "@types/aws-lambda",
+      "replacementVersion": "latest"
     }
   ],
   "branchConcurrentLimit": null,


### PR DESCRIPTION
We have far too many repos with a dependency on `aws-lambda` which I am very sure they meant to only include `@types/aws-lambda`

https://github.com/samchungy/renovate-experiments/pull/11