### PR TITLE
Ignore autofix commits for SEEK-Jobs and seek-oss

### DIFF
--- a/default.json
+++ b/default.json
@@ -266,6 +266,10 @@
   "branchConcurrentLimit": null,
   "branchPrefix": "renovate-",
   "commitMessageAction": "",
+  "gitIgnoredAuthors": [
+    "34733141+seek-oss-ci@users.noreply.github.com",
+    "87109344+buildagencygitapitoken[bot]@users.noreply.github.com"
+  ],
   "postUpdateOptions": ["yarnDedupeFewer", "pnpmDedupe"],
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,

--- a/non-critical.json
+++ b/non-critical.json
@@ -85,6 +85,10 @@
   "buildkite": { "additionalBranchPrefix": "", "commitMessageExtra": "" },
   "commitMessageAction": "",
   "commitMessageExtra": "",
+  "gitIgnoredAuthors": [
+    "34733141+seek-oss-ci@users.noreply.github.com",
+    "87109344+buildagencygitapitoken[bot]@users.noreply.github.com"
+  ],
   "postUpdateOptions": ["yarnDedupeFewer", "pnpmDedupe"],
   "prConcurrentLimit": 2,
   "prNotPendingHours": 1,

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -131,6 +131,10 @@
     }
   ],
   "commitMessageAction": "",
+  "gitIgnoredAuthors": [
+    "34733141+seek-oss-ci@users.noreply.github.com",
+    "87109344+buildagencygitapitoken[bot]@users.noreply.github.com"
+  ],
   "postUpdateOptions": ["yarnDedupeFewer", "pnpmDedupe"],
   "prConcurrentLimit": 3,
   "prNotPendingHours": 1,


### PR DESCRIPTION
Reinstates https://github.com/seek-oss/rynovate/pull/108 (reverted in https://github.com/seek-oss/rynovate/pull/109) now Renovate v38 is live (which includes https://github.com/renovatebot/renovate/pull/28225).