### PR TITLE
Enable docker digest pinning

### DIFF
--- a/default.json
+++ b/default.json
@@ -262,6 +262,17 @@
 
       "prPriority": 99,
       "schedule": "before 3:00 am every weekday"
+    },
+    {
+      "matchUpdateTypes": ["digest"],
+      "matchManagers": ["dockerfile"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["digest"],
+      "matchManagers": ["dockerfile"],
+      "schedule": ["before 7:00 am every week on Monday"],
+      "prPriority": 99
     }
   ],
   "branchConcurrentLimit": null,

--- a/default.json
+++ b/default.json
@@ -7,7 +7,8 @@
     "preview:buildkite",
     "preview:dockerCompose",
     "docker:disableMajor",
-    "group:monorepos"
+    "group:monorepos",
+    "docker:pinDigests"
   ],
   "lockFileMaintenance": {
     "enabled": true

--- a/default.json
+++ b/default.json
@@ -271,7 +271,7 @@
     {
       "matchUpdateTypes": ["digest"],
       "matchManagers": ["dockerfile"],
-      "schedule": ["before 7:00 am every week on Monday"],
+      "schedule": ["before 7:00 on Monday"],
       "prPriority": 99
     }
   ],

--- a/non-critical.json
+++ b/non-critical.json
@@ -8,7 +8,8 @@
     ":timezone(Australia/Melbourne)",
     "preview:buildkite",
     "preview:dockerCompose",
-    "docker:disableMajor"
+    "docker:disableMajor",
+    "docker:pinDigests"
   ],
   "lockFileMaintenance": { "enabled": true },
   "packageRules": [

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -9,7 +9,8 @@
     ":updateNotScheduled",
     "preview:buildkite",
     "preview:dockerCompose",
-    "docker:disableMajor"
+    "docker:disableMajor",
+    "docker:pinDigests"
   ],
   "lockFileMaintenance": {
     "enabled": true

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -129,6 +129,17 @@
 
       "prPriority": 99,
       "schedule": "before 3:00 am every weekday"
+    },
+    {
+      "matchUpdateTypes": ["digest"],
+      "matchManagers": ["dockerfile"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["digest"],
+      "matchManagers": ["dockerfile"],
+      "schedule": ["before 7:00 am every week on Monday"],
+      "prPriority": 99
     }
   ],
   "commitMessageAction": "",

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -138,7 +138,7 @@
     {
       "matchUpdateTypes": ["digest"],
       "matchManagers": ["dockerfile"],
-      "schedule": ["before 7:00 am every week on Monday"],
+      "schedule": ["before 7:00 on Monday"],
       "prPriority": 99
     }
   ],


### PR DESCRIPTION
This is important for reproducible builds. 

It's a best practise per Renovate, and they have a good explanation here: https://docs.renovatebot.com/docker/#digest-pinning.

> Digest Pinning
> We recommend that you pin your Docker images to an exact digest. By pinning to a digest you make your Docker builds immutable, every time you do a pull you get the same content.
> 
> If you work with dependencies in the JavaScript/npm ecosystem, you may be used to exact versions being immutable. For example, if you set a version like 2.0.1, you and your colleagues always get the exact same "code".
> 
> Docker's tags are not immutable versions, even if tags look like a version. You probably expect myimage:1 and > myimage:1.2 to change over time, but you might incorrectly assume that myimage:1.2.0 never changes. Although it probably shouldn't, the reality is that any Docker image tag can change content, and potentially break.
> 
> By replacing Docker tags with Docker digests as the image's primary identifier you'll get immutable builds. Working with strings like FROM node@sha256:d938c1761e3afbae9242848ffbb95b9cc1cb0a24d889f8bd955204d347a7266e is hard. > Luckily Renovate can update the digests for you.
> 
> When pinning a digest, Renovate retains the Docker tag in the FROM line for readability, like this: FROM node:14.15.1@sha256:d938c1761e3afbae9242848ffbb95b9cc1cb0a24d889f8bd955204d347a7266e.
