### PR TITLE
Try recreateWhen: always for digest pinning

### DIFF
--- a/default.json
+++ b/default.json
@@ -266,7 +266,8 @@
     {
       "matchUpdateTypes": ["digest", "pinDigest"],
       "matchManagers": ["dockerfile"],
-      "automerge": true
+      "automerge": true,
+      "recreateWhen": "always"
     },
     {
       "matchUpdateTypes": ["digest", "pinDigest"],

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -133,7 +133,8 @@
     {
       "matchUpdateTypes": ["digest", "pinDigest"],
       "matchManagers": ["dockerfile"],
-      "automerge": true
+      "automerge": true,
+      "recreateWhen": "always"
     },
     {
       "matchUpdateTypes": ["digest", "pinDigest"],


### PR DESCRIPTION
Raised by @juliuscheung. This might help with subsequent digest PRs refusing to be automerged.

