### PR TITLE
Unblock pnpm upgrades

### DIFF
--- a/default.json
+++ b/default.json
@@ -278,13 +278,6 @@
       "matchManagers": ["dockerfile"],
       "schedule": ["before 7:00 on Monday"],
       "prPriority": 99
-    },
-    {
-      "matchDepTypes": ["packageManager"],
-      "matchManagers": ["npm"],
-      "matchDepNames": ["pnpm"],
-
-      "allowedVersions": "<= 9.12.0"
     }
   ],
   "branchConcurrentLimit": null,


### PR DESCRIPTION
Reminder to revert #134 ~~once we have an upstream fix.~~

I think the issue was in mismatched versions, so this was not necessary to block.