### PR TITLE
Disable node majors

### DIFF
--- a/default.json
+++ b/default.json
@@ -51,6 +51,11 @@
       "enabled": false
     },
     {
+      "matchDepNames": ["node"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["npm"],
       "matchDepNames": ["serverless"],
       "matchUpdateTypes": ["major"],

--- a/non-critical.json
+++ b/non-critical.json
@@ -27,6 +27,11 @@
       "enabled": false
     },
     {
+      "matchDepNames": ["node"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["npm"],
       "matchDepNames": ["serverless"],
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
I thought we always had this tbh, but for the same reason we exclude `@types/node`, it doesn't really make sense to bump .nvmrc in isolation. Skuba intends to release an autofix to get us more of the way there in one bang, later this year.