### PR TITLE
Block renovation to `@aws-sdk/credential-providers` 3.730.0

### DIFF
--- a/default.json
+++ b/default.json
@@ -74,6 +74,12 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchDepNames": ["@aws-sdk/credential-providers"],
+
+      "allowedVersions": "< 3.730.0"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchDepNames": ["aws-sdk-mock"],
 
       "allowedVersions": "!/^5\\.5\\.0$/"

--- a/non-critical.json
+++ b/non-critical.json
@@ -50,6 +50,12 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchDepNames": ["@aws-sdk/credential-providers"],
+
+      "allowedVersions": "< 3.730.0"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchDepNames": ["aws-sdk-mock"],
       "allowedVersions": "!/^5\\.5\\.0$/"
     },

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -60,6 +60,12 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchDepNames": ["@aws-sdk/credential-providers"],
+
+      "allowedVersions": "< 3.730.0"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchDepNames": ["aws-sdk-mock"],
 
       "allowedVersions": "!/^5\\.5\\.0$/"


### PR DESCRIPTION
Hopefully this helps with the obvious cases, though the dependency could still be pulled in transitively.

https://github.com/aws/aws-sdk-js-v3/issues/6816