### PR TITLE
Allow `@aws-sdk/credential-providers` >3.730.0

### DIFF
--- a/default.json
+++ b/default.json
@@ -76,7 +76,7 @@
       "matchManagers": ["npm"],
       "matchDepNames": ["@aws-sdk/credential-providers"],
 
-      "allowedVersions": "< 3.730.0"
+      "allowedVersions": "!/^3\\.730\\.0$/"
     },
     {
       "matchManagers": ["npm"],

--- a/non-critical.json
+++ b/non-critical.json
@@ -52,7 +52,7 @@
       "matchManagers": ["npm"],
       "matchDepNames": ["@aws-sdk/credential-providers"],
 
-      "allowedVersions": "< 3.730.0"
+      "allowedVersions": "!/^3\\.730\\.0$/"
     },
     {
       "matchManagers": ["npm"],

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -62,7 +62,7 @@
       "matchManagers": ["npm"],
       "matchDepNames": ["@aws-sdk/credential-providers"],
 
-      "allowedVersions": "< 3.730.0"
+      "allowedVersions": "!/^3\\.730\\.0$/"
     },
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
Supersedes #155.