### PR TITLE
RFC: Disable renovation for pnpm >=9.15.5

### DIFF
--- a/default.json
+++ b/default.json
@@ -102,6 +102,11 @@
       "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
     },
     {
+      "matchDepNames": ["pnpm"],
+
+      "allowedVersions": "< 9.15.5"
+    },
+    {
       "matchManagers": ["npm"],
       "matchDepNames": ["/^@types//"],
       "matchUpdateTypes": ["major", "minor", "patch"],

--- a/non-critical.json
+++ b/non-critical.json
@@ -71,6 +71,11 @@
       "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
     },
     {
+      "matchDepNames": ["pnpm"],
+
+      "allowedVersions": "< 9.15.5"
+    },
+    {
       "matchDepNames": ["!seek-jobs/gantry", "!seek-jobs/automat", "!skuba"],
       "matchUpdateTypes": [
         "bump",

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -83,6 +83,11 @@
       "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
     },
     {
+      "matchDepNames": ["pnpm"],
+
+      "allowedVersions": "< 9.15.5"
+    },
+    {
       "matchDepNames": [
         "!braid-design-system",
         "!sku",


### PR DESCRIPTION
This may be too aggressive, but the idea is that we can sit tight for a few weeks to see whether Node.js 22 will bundle Corepack 0.31.

- https://github.com/seek-oss/aws-codedeploy-hooks/pull/93#pullrequestreview-2588647976
- https://togithub.com/nodejs/corepack/issues/612