### PR TITLE
Revert "RFC: Disable renovation for pnpm >=9.15.5"

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,9 +4,6 @@ on:
   - pull_request
   - push
 
-env:
-  COREPACK_DEFAULT_TO_LATEST: 0
-
 permissions: {}
 
 jobs:

--- a/default.json
+++ b/default.json
@@ -102,11 +102,6 @@
       "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
     },
     {
-      "matchDepNames": ["pnpm"],
-
-      "allowedVersions": "< 9.15.5"
-    },
-    {
       "matchManagers": ["npm"],
       "matchDepNames": ["/^@types//"],
       "matchUpdateTypes": ["major", "minor", "patch"],

--- a/non-critical.json
+++ b/non-critical.json
@@ -71,11 +71,6 @@
       "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
     },
     {
-      "matchDepNames": ["pnpm"],
-
-      "allowedVersions": "< 9.15.5"
-    },
-    {
       "matchDepNames": ["!seek-jobs/gantry", "!seek-jobs/automat", "!skuba"],
       "matchUpdateTypes": [
         "bump",

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -83,11 +83,6 @@
       "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
     },
     {
-      "matchDepNames": ["pnpm"],
-
-      "allowedVersions": "< 9.15.5"
-    },
-    {
       "matchDepNames": [
         "!braid-design-system",
         "!sku",


### PR DESCRIPTION
With Node LTS v22 and v20 now including Corepack `v0.31`, [this restriction](https://github.com/seek-oss/rynovate/pull/160) is no longer necessary.