### PR TITLE
Block dd-trace 5.41+

### DIFF
--- a/default.json
+++ b/default.json
@@ -104,7 +104,7 @@
       "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
 
-      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
+      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0|5\\.4[1-9]\\.\\d+)$/"
     },
     {
       "matchManagers": ["npm"],

--- a/non-critical.json
+++ b/non-critical.json
@@ -68,7 +68,7 @@
       "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
 
-      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
+      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0|5\\.4[1-9]\\.\\d+)$/"
     },
     {
       "matchDepNames": ["!seek-jobs/gantry", "!seek-jobs/automat", "!skuba"],

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -80,7 +80,7 @@
       "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
 
-      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0)$/"
+      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0|5\\.4[1-9]\\.\\d+)$/"
     },
     {
       "matchDepNames": [


### PR DESCRIPTION
I can see this causing some latency issues in one of my systems, and there are open-source reported issues with memory leaks in 5.41.x-5.43.x (latest) inclusive