### PR TITLE
Allow dd-trace 5.44.x+

### DIFF
--- a/default.json
+++ b/default.json
@@ -104,7 +104,7 @@
       "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
 
-      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0|5\\.4[1-9]\\.\\d+)$/"
+      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0|5\\.4[1-3]\\.\\d+)$/"
     },
     {
       "matchManagers": ["npm"],

--- a/non-critical.json
+++ b/non-critical.json
@@ -68,7 +68,7 @@
       "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
 
-      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0|5\\.4[1-9]\\.\\d+)$/"
+      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0|5\\.4[1-3]\\.\\d+)$/"
     },
     {
       "matchDepNames": ["!seek-jobs/gantry", "!seek-jobs/automat", "!skuba"],

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -80,7 +80,7 @@
       "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
 
-      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0|5\\.4[1-9]\\.\\d+)$/"
+      "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0|5\\.4[1-3]\\.\\d+)$/"
     },
     {
       "matchDepNames": [


### PR DESCRIPTION
Issues appears to be fixed in 5.44.0: https://github.com/DataDog/dd-trace-js/issues/5394

Seems happy in one of my services that was previously affected. 