### PR TITLE
Block koa majors

### DIFF
--- a/default.json
+++ b/default.json
@@ -71,6 +71,11 @@
       "enabled": false
     },
     {
+      "matchDepNames": ["koa"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
       "matchUpdateTypes": ["major", "minor"],

--- a/non-critical.json
+++ b/non-critical.json
@@ -42,6 +42,11 @@
       "enabled": false
     },
     {
+      "matchDepNames": ["koa"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
       "matchUpdateTypes": ["major", "minor"],

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -59,6 +59,11 @@
       "enabled": false
     },
     {
+      "matchDepNames": ["koa"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["npm"],
       "matchDepNames": ["@aws-sdk/credential-providers"],
 


### PR DESCRIPTION
I'd like us to have some time to deal with e.g. seek-oss/koala first, before these come through. I'm not 100% sure koa 3 will break things, but hoping to let things settle first, anyway.

https://github.com/koajs/koa/releases/tag/v3.0.0