### PR TITLE
Block @types/koa-bodyparser v5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "prettier --check .",
-    "test": "concurrently yarn:test:*",
+    "test": "concurrently pnpm:test:*",
     "test:default": "RENOVATE_CONFIG_FILE=default.json renovate-config-validator",
     "test:non-critical": "RENOVATE_CONFIG_FILE=non-critical.json renovate-config-validator",
     "test:third-party-major": "RENOVATE_CONFIG_FILE=third-party-major.json renovate-config-validator"

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -65,6 +65,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchDepNames": ["@types/koa-bodyparser"],
+      "allowedVersions": "!/^5\\.0\\.2$/"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchDepNames": ["@aws-sdk/credential-providers"],
 
       "allowedVersions": "!/^3\\.730\\.0$/"


### PR DESCRIPTION
Renovate raised a PR to update to [this version](https://www.npmjs.com/package/@types/koa-bodyparser/v/5.0.2) which was published 7 years ago and doesn't seem to exist on the versions page 🤔 