### PR TITLE
Block @types/koa-bodyparser v5.0.2

### DIFF
--- a/default.json
+++ b/default.json
@@ -77,6 +77,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchDepNames": ["@types/koa-bodyparser"],
+      "allowedVersions": "!/^5\\.0\\.2$/"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
       "matchUpdateTypes": ["major", "minor"],
 

--- a/non-critical.json
+++ b/non-critical.json
@@ -48,6 +48,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchDepNames": ["@types/koa-bodyparser"],
+      "allowedVersions": "!/^5\\.0\\.2$/"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
       "matchUpdateTypes": ["major", "minor"],
 


### PR DESCRIPTION
Actually block `@types/koa-bodyparser` v5.0.2 extending https://github.com/seek-oss/rynovate/pull/173