### PR TITLE
Block @types/koa-bodyparser v5.0.0 & v5.0.1

### DIFF
--- a/default.json
+++ b/default.json
@@ -78,7 +78,7 @@
     {
       "matchManagers": ["npm"],
       "matchDepNames": ["@types/koa-bodyparser"],
-      "allowedVersions": "!/^5\\.0\\.2$/"
+      "allowedVersions": "!/^5\\.0\\.[0-2]$/"
     },
     {
       "matchManagers": ["npm"],

--- a/non-critical.json
+++ b/non-critical.json
@@ -49,7 +49,7 @@
     {
       "matchManagers": ["npm"],
       "matchDepNames": ["@types/koa-bodyparser"],
-      "allowedVersions": "!/^5\\.0\\.2$/"
+      "allowedVersions": "!/^5\\.0\\.[0-2]$/"
     },
     {
       "matchManagers": ["npm"],

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -66,7 +66,7 @@
     {
       "matchManagers": ["npm"],
       "matchDepNames": ["@types/koa-bodyparser"],
-      "allowedVersions": "!/^5\\.0\\.2$/"
+      "allowedVersions": "!/^5\\.0\\.[0-2]$/"
     },
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
Turns out there are two more [v5.0.0](https://www.npmjs.com/package/@types/koa-bodyparser/v/5.0.0) & [v5.0.1](https://www.npmjs.com/package/@types/koa-bodyparser/v/5.0.1)

Extending https://github.com/seek-oss/rynovate/pull/174 again...