### PR TITLE
Disable `dotenv` >=17

### DIFF
--- a/internal-shared.json
+++ b/internal-shared.json
@@ -44,6 +44,12 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchDepNames": ["dotenv"],
+
+      "allowedVersions": "< 17"
+    },
+    {
+      "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
 
       "allowedVersions": "!/^(3\\.42\\.0|4\\.21\\.0|5\\.4[1-3]\\.\\d+)$/"


### PR DESCRIPTION
Latest major spams stdout by default.

https://github.com/motdotla/dotenv/blob/v17.2.1/CHANGELOG.md#1721-2025-07-24