### PR TITLE
Unblock koa upgrades

### DIFF
--- a/internal-shared.json
+++ b/internal-shared.json
@@ -11,7 +11,6 @@
         "react-dom",
         "@types/react",
         "@types/react-dom",
-        "koa",
         "gaxios"
       ],
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
@types/koa is now out, and the breaking change is relatively mild for koa 3. We should be good to go.

https://github.com/seek-oss/skuba/pull/1974
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73346
https://github.com/seek-oss/koala/pull/312