### PR TITLE
Update rules for `gantry` and `automat`

### DIFF
--- a/default.json
+++ b/default.json
@@ -171,10 +171,24 @@
     },
     {
       "matchManagers": ["buildkite"],
-      "matchDepNames": ["seek-jobs/gantry", "seek-jobs/automat"],
+      "matchDepNames": ["seek-jobs/gantry"],
 
       "schedule": "after 3:00 am and before 5:00 pm every weekday",
-      "minimumReleaseAge": "0 days",
+      "minimumReleaseAge": "1 hour",
+      "updateNotScheduled": true
+    },
+    {
+      "matchManagers": ["buildkite"],
+      "matchDepNames": ["seek-jobs/automat"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["buildkite"],
+      "matchDepNames": ["seek-jobs/automat"],
+
+      "schedule": "after 3:00 am and before 5:00 pm every weekday",
+      "minimumReleaseAge": "1 hour",
       "updateNotScheduled": true
     },
     {


### PR DESCRIPTION
**Changes**

- Changed minimumReleaseAge to 1 hour. This gives us a little time to react if a bad release goes out.
- Added a new entry for `seek-jobs/automat` with major update types disabled. We want to be sure people aren't automatically upgrading to a major release via renovate since major changes usually will mean some manual intervention is required.