### PR TITLE
Exclude `serverless` from `npm dev dependencies` group

### DIFF
--- a/default.json
+++ b/default.json
@@ -106,15 +106,16 @@
     },
     {
       "matchDepNames": [
-        "!aws-sdk",
-        "!braid-design-system",
-        "!sku",
-        "!skuba",
         "!/^@?seek/",
-        "!/seek$/",
         "!/^@aws-sdk//",
         "!/^@types//",
-        "!/^@vanilla-extract//"
+        "!/^@vanilla-extract//",
+        "!/seek$/",
+        "!aws-sdk",
+        "!braid-design-system",
+        "!serverless",
+        "!sku",
+        "!skuba"
       ],
       "matchDepTypes": ["devDependencies"],
       "matchManagers": ["npm"],


### PR DESCRIPTION
The aim of https://github.com/seek-oss/rynovate/pull/199 was to group the upgrading of serverless together like [this](https://github.com/zbrydon/test-renovate/pull/10). 

For some reason we saw
- https://github.com/SEEK-Jobs/indie-fka-twigs-crew/pull/2326 update the `serverless.yml`

followed by
- https://github.com/SEEK-Jobs/indie-fka-twigs-crew/pull/2329 update the `package.json` 

Since the second PR was a `npm dev dependencies` I am excluding serverless from that group, but this is a complete guess. 
Mainly because I expected the `package.json` version to have been caught and updated via
https://github.com/seek-oss/rynovate/blob/d82fffcf9accdf71bf563a5ade9d8fd35b71c893/default.json#L101-L106