### PR TITLE
Try to force `@seek/melways-sites` PRs again

### DIFF
--- a/default.json
+++ b/default.json
@@ -335,6 +335,13 @@
       "matchManagers": ["dockerfile"],
       "schedule": ["before 7:00 on Monday"],
       "prPriority": 99
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepNames": ["@seek/melways-sites"],
+      "prConcurrentLimit": 0,
+      "prPriority": 100,
+      "schedule": "at any time"
     }
   ],
   "customManagers": [

--- a/internal-shared.json
+++ b/internal-shared.json
@@ -94,13 +94,6 @@
       "matchDatasources": ["docker"],
       "matchDepNames": ["/(?:^|\\/)node$/"],
       "allowedVersions": "< 25"
-    },
-    {
-      "matchManagers": ["npm"],
-      "matchDepNames": ["@seek/melways-sites"],
-      "prConcurrentLimit": 0,
-      "prPriority": 100,
-      "schedule": "at any time"
     }
   ],
   "gitIgnoredAuthors": [

--- a/non-critical.json
+++ b/non-critical.json
@@ -70,6 +70,13 @@
       "matchUpdateTypes": ["lockFileMaintenance"],
       "prPriority": 99,
       "schedule": "before 3:00 am every 2 weeks on Wednesday"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepNames": ["@seek/melways-sites"],
+      "prConcurrentLimit": 0,
+      "prPriority": 100,
+      "schedule": "at any time"
     }
   ],
   "buildkite": { "additionalBranchPrefix": "", "commitMessageExtra": "" },

--- a/third-party-major.json
+++ b/third-party-major.json
@@ -122,6 +122,13 @@
       "matchManagers": ["dockerfile"],
       "schedule": ["before 7:00 on Monday"],
       "prPriority": 99
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepNames": ["@seek/melways-sites"],
+      "prConcurrentLimit": 0,
+      "prPriority": 100,
+      "schedule": "at any time"
     }
   ],
   "commitMessageAction": "",


### PR DESCRIPTION
I think there's a precedence issue in #244 as `internal-shared` package rules are evaluated before the ones defined in the preset. This meant that rules matching on e.g. a `@seek/` prefix overrode the schedule.