### PR TITLE
Block axios

### DIFF
--- a/internal-shared.json
+++ b/internal-shared.json
@@ -94,6 +94,11 @@
       "matchDatasources": ["docker"],
       "matchDepNames": ["/(?:^|\\/)node$/"],
       "allowedVersions": "< 25"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepNames": ["axios"],
+      "allowedVersions": "!/^(1\\.14\\.1|0\\.30\\.4)$/"
     }
   ],
   "gitIgnoredAuthors": [


### PR DESCRIPTION
There's a supply chain attack happen on Axios
https://github.com/axios/axios/issues/10604

Not sure if we should use `"enabled": false` or just block for these versions