### PR TITLE
Pin GitHub Action digests

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,6 +10,7 @@
     "docker:enableMajor",
     "group:monorepos",
     "docker:pinDigests",
+    "helpers:pinGitHubActionDigests",
     "github>seek-oss/rynovate:internal-shared"
   ],
   "packageRules": [


### PR DESCRIPTION
Prevent some easy supply chain attack vectors on our GitHub Actions:

It also adds the version as a comment :)

https://github.com/samchungy/renovate-experiments/pull/84/changes

<img width="1219" height="694" alt="image" src="https://github.com/user-attachments/assets/48cf64bf-303f-42f3-af25-f0bdb4caf9b6" />
