### PR TITLE
Change prCreation to not-pending

### DIFF
--- a/default.json
+++ b/default.json
@@ -383,7 +383,7 @@
   "prConcurrentLimit": 3,
   "rangeStrategy": "replace",
   "schedule": "after 3:00 am and before 6:00 am on Monday and Friday",
-  "prCreation": "immediate",
+  "prCreation": "not-pending",
   "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
   "updateNotScheduled": false


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days

I've seen some PRs raised recently that haven't met stability days, I would like to not see them anymore please