### PR TITLE
RFC: Disable minimum release age on Docker images

### DIFF
--- a/default.json
+++ b/default.json
@@ -330,13 +330,13 @@
       "matchManagers": ["dockerfile"],
       "automerge": true,
       "recreateWhen": "always",
-      "minimumReleaseAgeBehaviour": "timestamp-optional"
+      "minimumReleaseAge": null
     },
     {
       "matchUpdateTypes": ["digest", "pinDigest"],
       "matchManagers": ["dockerfile"],
       "schedule": ["before 7:00 on Monday"],
-      "minimumReleaseAgeBehaviour": "timestamp-optional",
+      "minimumReleaseAge": null,
       "prPriority": 99
     },
     {

--- a/default.json
+++ b/default.json
@@ -330,13 +330,13 @@
       "matchManagers": ["dockerfile"],
       "automerge": true,
       "recreateWhen": "always",
-      "minimumReleaseAge": null
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
       "matchUpdateTypes": ["digest", "pinDigest"],
       "matchManagers": ["dockerfile"],
       "schedule": ["before 7:00 on Monday"],
-      "minimumReleaseAge": null,
+      "minimumReleaseAgeBehaviour": "timestamp-optional",
       "prPriority": 99
     },
     {

--- a/default.json
+++ b/default.json
@@ -329,12 +329,14 @@
       "matchUpdateTypes": ["digest", "pinDigest"],
       "matchManagers": ["dockerfile"],
       "automerge": true,
-      "recreateWhen": "always"
+      "recreateWhen": "always",
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
       "matchUpdateTypes": ["digest", "pinDigest"],
       "matchManagers": ["dockerfile"],
       "schedule": ["before 7:00 on Monday"],
+      "minimumReleaseAgeBehaviour": "timestamp-optional",
       "prPriority": 99
     },
     {

--- a/internal-shared.json
+++ b/internal-shared.json
@@ -78,17 +78,20 @@
     {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["gcr.io/distroless/nodejs20-debian12"],
-      "replacementName": "gcr.io/distroless/nodejs20-debian13"
+      "replacementName": "gcr.io/distroless/nodejs20-debian13",
+      "minimumReleaseAge": null
     },
     {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["gcr.io/distroless/nodejs22-debian12"],
-      "replacementName": "gcr.io/distroless/nodejs22-debian13"
+      "replacementName": "gcr.io/distroless/nodejs22-debian13",
+      "minimumReleaseAge": null
     },
     {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["gcr.io/distroless/nodejs24-debian12"],
-      "replacementName": "gcr.io/distroless/nodejs24-debian13"
+      "replacementName": "gcr.io/distroless/nodejs24-debian13",
+      "minimumReleaseAge": null
     },
     {
       "matchDatasources": ["docker"],

--- a/internal-shared.json
+++ b/internal-shared.json
@@ -79,19 +79,19 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["gcr.io/distroless/nodejs20-debian12"],
       "replacementName": "gcr.io/distroless/nodejs20-debian13",
-      "minimumReleaseAge": null
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["gcr.io/distroless/nodejs22-debian12"],
       "replacementName": "gcr.io/distroless/nodejs22-debian13",
-      "minimumReleaseAge": null
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["gcr.io/distroless/nodejs24-debian12"],
       "replacementName": "gcr.io/distroless/nodejs24-debian13",
-      "minimumReleaseAge": null
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
Our docker image pin PRs are constantly pending:

<img width="823" height="125" alt="image" src="https://github.com/user-attachments/assets/e7977055-b87e-4278-ae5e-07e4578c0480" />

https://github.com/renovatebot/renovate/blob/13128801b429f46cf1f7f9a603cd697153890660/lib/modules/datasource/docker/index.ts#L88

Looks like it doesn't support release timestamps so these PRs would never be raised ever:

https://docs.renovatebot.com/key-concepts/minimum-release-age/

<img width="794" height="545" alt="image" src="https://github.com/user-attachments/assets/8ab075d0-a5c4-4704-a260-b1966a9e05ae" />
