### PR TITLE
Use better GitHub Actions preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,7 @@
     "docker:enableMajor",
     "group:monorepos",
     "docker:pinDigests",
-    "helpers:pinGitHubActionDigests",
+    "helpers:pinGitHubActionDigestsToSemver",
     "github>seek-oss/rynovate:internal-shared"
   ],
   "packageRules": [


### PR DESCRIPTION
Follow up to https://github.com/seek-oss/rynovate/pull/249

This previous one sets the comment to a major and gives you useless follow ups like:

<img width="1191" height="553" alt="image" src="https://github.com/user-attachments/assets/45278006-7484-4dea-8cb2-6e7b106a9fe8" />

This preset gives us the semver within the comment:

<img width="1219" height="320" alt="image" src="https://github.com/user-attachments/assets/5bf09bdb-fa10-4abd-965c-3a18ca4ad8b1" />
