### PR TITLE
Block pnpm v11

### DIFF
--- a/default.json
+++ b/default.json
@@ -73,6 +73,7 @@
     {
       "matchDepNames": ["pnpm"],
       "matchUpdateTypes": ["major"],
+      "matchNewValue": "/^11/",
       "enabled": false
     },
     {

--- a/default.json
+++ b/default.json
@@ -71,6 +71,11 @@
       "automerge": true
     },
     {
+      "matchDepNames": ["pnpm"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["npm"],
       "matchDepNames": ["/^@types//"],
       "matchUpdateTypes": ["major", "minor", "patch"],

--- a/internal-shared.json
+++ b/internal-shared.json
@@ -13,6 +13,7 @@
     {
       "matchDepNames": ["pnpm"],
       "matchUpdateTypes": ["major"],
+      "matchNewValue": "/^11/",
       "enabled": false
     },
     {

--- a/internal-shared.json
+++ b/internal-shared.json
@@ -11,6 +11,11 @@
       "enabled": false
     },
     {
+      "matchDepNames": ["pnpm"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],
       "matchUpdateTypes": ["major", "minor"],

--- a/non-critical.json
+++ b/non-critical.json
@@ -30,6 +30,11 @@
       "enabled": false
     },
     {
+      "matchDepNames": ["pnpm"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchDepNames": ["!seek-jobs/gantry", "!seek-jobs/automat", "!skuba"],
       "matchUpdateTypes": [
         "bump",

--- a/non-critical.json
+++ b/non-critical.json
@@ -32,6 +32,7 @@
     {
       "matchDepNames": ["pnpm"],
       "matchUpdateTypes": ["major"],
+      "matchNewValue": "/^11/",
       "enabled": false
     },
     {


### PR DESCRIPTION
pnpm 11 does not work well with aws-cdk-lambda-nodejs. This could be fixed a few ways but I think getting upstream support is ideal. 
https://github.com/aws/aws-cdk/issues/37898
https://github.com/pnpm/pnpm/issues/10988