### PR TITLE
Create separate configs for `sku` and `braid-design-system` deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -178,10 +178,26 @@
         "eslint-config-seek",
         "eslint-config-skuba",
         "eslint-plugin-skuba",
-        "tsconfig-seek",
-        "braid-design-system",
-        "sku"
+        "tsconfig-seek"
       ],
+
+      "prPriority": 98,
+      "schedule": "after 3:00 am and before 6:00 am every weekday",
+      "minimumReleaseAge": "0 days",
+      "updateNotScheduled": true
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepNames": ["braid-design-system", "/^@braid-design-system//"],
+
+      "prPriority": 98,
+      "schedule": "after 3:00 am and before 6:00 am every weekday",
+      "minimumReleaseAge": "0 days",
+      "updateNotScheduled": true
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepNames": ["sku", "/^@sku-lib//", "pnpm-plugin-sku"],
 
       "prPriority": 98,
       "schedule": "after 3:00 am and before 6:00 am every weekday",


### PR DESCRIPTION
Splitting out braid and sku deps into their own separate groups (including their respective scopes) to mimic the existing `skuba` group.