### PR TITLE
Skip TypeScript 7.0.x

### DIFF
--- a/internal-shared.json
+++ b/internal-shared.json
@@ -48,6 +48,12 @@
       "allowedVersions": "< 17"
     },
     {
+      "description": "https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/ — TS 7.0 has no JS programmatic API (expected in 7.1); breaks typescript-eslint/skuba. Allow <7 or >=7.1.",
+      "matchManagers": ["npm"],
+      "matchDepNames": ["typescript"],
+      "allowedVersions": "<7.0.0 || >=7.1.0"
+    },
+    {
       "description": "https://github.com/search?q=repo%3Aseek-oss%2Frynovate+dd-trace&type=pullrequests",
       "matchManagers": ["npm"],
       "matchDepNames": ["dd-trace"],


### PR DESCRIPTION
#### Card

N/A

#### Context

[TypeScript 7.0](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/) ships without a JavaScript programmatic API (expected in 7.1). That breaks `typescript-eslint`, skuba lint, and anything that `import`s `typescript`. Renovate is already proposing `typescript@^7.0` upgrades that teams then have to close or revert.

#### Change

Add an `allowedVersions` package rule in `internal-shared.json` so all named presets inherit it:

- match npm `typescript`
- allow `<7.0.0 || >=7.1.0` (skip the 7.0.x line only)

See individual commits for finer details.

#### Confirmation

- `pnpm test` (renovate-config-validator for `default`, `non-critical`, and `third-party-major`) passes on this branch.
- After merge, watch Renovate on a rynovate consumer: new PRs should stop targeting `typescript@7.0.x`, while upgrades to `>=7.1.0` (when published) remain allowed.

#### Considerations

- Repos that intentionally dual-install TypeScript 7.0 (e.g. via npm aliases) can override with a local `packageRules` entry; rynovate does not special-case that path.
- This is a temporary ecosystem guard until 7.1’s API lands; the rule can stay as a historical skip of the 7.0 line even after 7.1 exists.